### PR TITLE
Disabling code splitting

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,74 +1,25 @@
-on:
-  push:
-    branches:
-      - '**' # matches every branch
-
+on: [push, pull_request]
+    
 jobs:
-  Deploy:
+  Publish:
     runs-on: ubuntu-latest
+    name: Snap Action
     steps:
-      - name: Checkout repositiory
+      - name: checkout action
         uses: actions/checkout@v2
-
-      - name: Setup Node
-        uses: actions/setup-node@v2
         with:
-          node-version: 16
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@searchspring'
-
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules
+          repository: searchspring/snap-action
+          token: ${{ secrets.ACTION_PAT }}
+      - name: Run @searchspring/snap-action
+        uses: ./
         with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
-      - name: Install packages
-        run: npm install
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.PACKAGE_TOKEN }}
-
-      - name: Build bundle
-        run: npm run build
-
-      - name: Run Tests
-        run: npm run test
-
-      - name: Extract Variables
-        id: variables
-        shell: bash
-        run: |
-          branch=`echo ${GITHUB_REF#refs/heads/}`
-          echo "::set-output name=branch::$branch"
-          echo "Using branch: $branch"
-          siteId=`jq -r '.searchspring.siteId' < package.json`
-          echo "::set-output name=siteId::$siteId"
-          echo "Using siteId: $siteId"
-
-      - name: Configure AWS credentials from Production account
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
+        # required
+          repository: ${{ env.GITHUB_REPOSITORY }}
+          secretKey: ${{ secrets.WEBSITE_SECRET_KEY }}
           aws-access-key-id: ${{ secrets.SNAPFU_AWS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.SNAPFU_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-2
-
-      - name: Copy Files to S3
-        run: |
-          aws s3 sync --delete --acl public-read dist s3://${{secrets.SNAPFU_AWS_BUCKET}}/${{ steps.variables.outputs.siteId }}/${{ steps.variables.outputs.branch }}
-          aws s3 sync --delete --acl public-read public s3://${{secrets.SNAPFU_AWS_BUCKET}}/${{ steps.variables.outputs.siteId }}/${{ steps.variables.outputs.branch }}/public
-
-      - name: Invalidate Branch Files
-        run: |
-          aws cloudfront create-invalidation --distribution-id ${{secrets.SNAPFU_AWS_DISTRIBUTION_ID}} --paths "/${{ steps.variables.outputs.siteId }}/${{ steps.variables.outputs.branch }}/*"
-
-      - name: Invalidate Integration Script
-        if: steps.variables.outputs.branch == 'production'
-        run: |
-          aws cloudfront create-invalidation --distribution-id ${{secrets.SNAPFU_AWS_DISTRIBUTION_ID}} --paths "/${{ steps.variables.outputs.siteId }}/bundle.js"
+          aws-cloudfront-distribution-id: ${{secrets.SNAPFU_AWS_DISTRIBUTION_ID}}
+          aws-s3-bucket-name: ${{secrets.SNAPFU_AWS_BUCKET}}
+        # optional
+          NODE_AUTH_TOKEN: ${{ secrets.PACKAGE_TOKEN }}
+          GITHUB_BOT_TOKEN: ${{ secrets.MACHINE_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
 			"version": "0.0.1",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-preact": "^0.9.3",
-				"@searchspring/snap-preact-components": "^0.9.3",
+				"@searchspring/snap-preact": "^0.9.7",
+				"@searchspring/snap-preact-components": "^0.9.7",
 				"mobx": "^6.3.3",
 				"mobx-react": "^7.2.0",
 				"preact": "^10.5.14"
@@ -50,9 +50,9 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-			"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
+			"integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
 			"devOptional": true,
 			"dependencies": {
 				"@babel/highlight": "^7.14.5"
@@ -71,20 +71,20 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.15.5",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.5.tgz",
-			"integrity": "sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.8.tgz",
+			"integrity": "sha512-3UG9dsxvYBMYwRv+gS41WKHno4K60/9GPy1CJaH6xy3Elq8CTtvtjT5R5jmNhXfCYLX2mTw+7/aq5ak/gOE0og==",
 			"devOptional": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.14.5",
-				"@babel/generator": "^7.15.4",
+				"@babel/code-frame": "^7.15.8",
+				"@babel/generator": "^7.15.8",
 				"@babel/helper-compilation-targets": "^7.15.4",
-				"@babel/helper-module-transforms": "^7.15.4",
+				"@babel/helper-module-transforms": "^7.15.8",
 				"@babel/helpers": "^7.15.4",
-				"@babel/parser": "^7.15.5",
+				"@babel/parser": "^7.15.8",
 				"@babel/template": "^7.15.4",
 				"@babel/traverse": "^7.15.4",
-				"@babel/types": "^7.15.4",
+				"@babel/types": "^7.15.6",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -101,12 +101,12 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.15.4",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
-			"integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
+			"integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
 			"devOptional": true,
 			"dependencies": {
-				"@babel/types": "^7.15.4",
+				"@babel/types": "^7.15.6",
 				"jsesc": "^2.5.1",
 				"source-map": "^0.5.0"
 			},
@@ -287,19 +287,19 @@
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.15.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.4.tgz",
-			"integrity": "sha512-9fHHSGE9zTC++KuXLZcB5FKgvlV83Ox+NLUmQTawovwlJ85+QMhk1CnVk406CQVj97LaWod6KVjl2Sfgw9Aktw==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.8.tgz",
+			"integrity": "sha512-DfAfA6PfpG8t4S6npwzLvTUpp0sS7JrcuaMiy1Y5645laRJIp/LiLGIBbQKaXSInK8tiGNI7FL7L8UvB8gdUZg==",
 			"devOptional": true,
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.15.4",
 				"@babel/helper-replace-supers": "^7.15.4",
 				"@babel/helper-simple-access": "^7.15.4",
 				"@babel/helper-split-export-declaration": "^7.15.4",
-				"@babel/helper-validator-identifier": "^7.14.9",
+				"@babel/helper-validator-identifier": "^7.15.7",
 				"@babel/template": "^7.15.4",
 				"@babel/traverse": "^7.15.4",
-				"@babel/types": "^7.15.4"
+				"@babel/types": "^7.15.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -392,9 +392,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.14.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-			"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+			"version": "7.15.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+			"integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
 			"devOptional": true,
 			"engines": {
 				"node": ">=6.9.0"
@@ -453,9 +453,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.15.6",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.6.tgz",
-			"integrity": "sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
+			"integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
 			"devOptional": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -482,9 +482,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.15.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.15.4.tgz",
-			"integrity": "sha512-2zt2g5vTXpMC3OmK6uyjvdXptbhBXfA77XGrd3gh93zwG8lZYBLOBImiGBEG0RANu3JqKEACCz5CGk73OJROBw==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.15.8.tgz",
+			"integrity": "sha512-2Z5F2R2ibINTc63mY7FLqGfEbmofrHU9FitJW1Q7aPaKFhiPvSq6QEt/BoWN5oME3GVyjcRuNNSRbb9LC0CSWA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.14.5",
@@ -532,9 +532,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-proposal-decorators": {
-			"version": "7.15.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.15.4.tgz",
-			"integrity": "sha512-WNER+YLs7avvRukEddhu5PSfSaMMimX2xBFgLQS7Bw16yrUxJGWidO9nQp+yLy9MVybg5Ba3BlhAw+BkdhpDmg==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.15.8.tgz",
+			"integrity": "sha512-5n8+xGK7YDrXF+WAORg3P7LlCCdiaAyKLZi22eP2BwTy4kJ0kFUMMDCj4nQ8YrKyNZgjhU/9eRVqONnjB3us8g==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-create-class-features-plugin": "^7.15.4",
@@ -1416,15 +1416,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-runtime": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.15.0.tgz",
-			"integrity": "sha512-sfHYkLGjhzWTq6xsuQ01oEsUYjkHRux9fW1iUA68dC7Qd8BS1Unq4aZ8itmQp95zUzIcyR2EbNMTzAicFj+guw==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.15.8.tgz",
+			"integrity": "sha512-+6zsde91jMzzvkzuEA3k63zCw+tm/GvuuabkpisgbDMTPQsIMHllE3XczJFFtEHLjjhKQFZmGQVRdELetlWpVw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.14.5",
+				"@babel/helper-module-imports": "^7.15.4",
 				"@babel/helper-plugin-utils": "^7.14.5",
 				"babel-plugin-polyfill-corejs2": "^0.2.2",
-				"babel-plugin-polyfill-corejs3": "^0.2.2",
+				"babel-plugin-polyfill-corejs3": "^0.2.5",
 				"babel-plugin-polyfill-regenerator": "^0.2.2",
 				"semver": "^6.3.0"
 			},
@@ -1451,13 +1451,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-spread": {
-			"version": "7.14.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.14.6.tgz",
-			"integrity": "sha512-Zr0x0YroFJku7n7+/HH3A2eIrGMjbmAIbJSVv0IZ+t3U2WUQUA64S/oeied2e+MaGSjmt4alzBCsK9E8gh+fag==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.15.8.tgz",
+			"integrity": "sha512-/daZ8s2tNaRekl9YJa9X4bzjpeRZLt122cpgFnQPLGUe61PH8zMEBmYqKkW5xF5JUEh5buEGXJoQpqBmIbpmEQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.14.5",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.14.5"
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.15.4"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1543,9 +1543,9 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.15.6",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.15.6.tgz",
-			"integrity": "sha512-L+6jcGn7EWu7zqaO2uoTDjjMBW+88FXzV8KvrBl2z6MtRNxlsmUNRlZPaNNPUTgqhyC5DHNFk/2Jmra+ublZWw==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.15.8.tgz",
+			"integrity": "sha512-rCC0wH8husJgY4FPbHsiYyiLxSY8oMDJH7Rl6RQMknbN9oDDHhM9RDFvnGM2MgkbUJzSQB4gtuwygY5mCqGSsA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/compat-data": "^7.15.0",
@@ -1553,7 +1553,7 @@
 				"@babel/helper-plugin-utils": "^7.14.5",
 				"@babel/helper-validator-option": "^7.14.5",
 				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.15.4",
-				"@babel/plugin-proposal-async-generator-functions": "^7.15.4",
+				"@babel/plugin-proposal-async-generator-functions": "^7.15.8",
 				"@babel/plugin-proposal-class-properties": "^7.14.5",
 				"@babel/plugin-proposal-class-static-block": "^7.15.4",
 				"@babel/plugin-proposal-dynamic-import": "^7.14.5",
@@ -1608,7 +1608,7 @@
 				"@babel/plugin-transform-regenerator": "^7.14.5",
 				"@babel/plugin-transform-reserved-words": "^7.14.5",
 				"@babel/plugin-transform-shorthand-properties": "^7.14.5",
-				"@babel/plugin-transform-spread": "^7.14.6",
+				"@babel/plugin-transform-spread": "^7.15.8",
 				"@babel/plugin-transform-sticky-regex": "^7.14.5",
 				"@babel/plugin-transform-template-literals": "^7.14.5",
 				"@babel/plugin-transform-typeof-symbol": "^7.14.5",
@@ -1617,7 +1617,7 @@
 				"@babel/preset-modules": "^0.1.4",
 				"@babel/types": "^7.15.6",
 				"babel-plugin-polyfill-corejs2": "^0.2.2",
-				"babel-plugin-polyfill-corejs3": "^0.2.2",
+				"babel-plugin-polyfill-corejs3": "^0.2.5",
 				"babel-plugin-polyfill-regenerator": "^0.2.2",
 				"core-js-compat": "^3.16.0",
 				"semver": "^6.3.0"
@@ -1964,9 +1964,9 @@
 			}
 		},
 		"node_modules/@polka/url": {
-			"version": "1.0.0-next.20",
-			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.20.tgz",
-			"integrity": "sha512-88p7+M0QGxKpmnkfXjS4V26AnoC/eiqZutE8GLdaI5X12NY75bXSdTY9NkmYb2Xyk1O+MmkuO6Frmsj84V6I8Q==",
+			"version": "1.0.0-next.21",
+			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
+			"integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
 			"dev": true
 		},
 		"node_modules/@prefresh/babel-plugin": {
@@ -2013,63 +2013,63 @@
 			"license": "MIT"
 		},
 		"node_modules/@searchspring/snap-client": {
-			"version": "0.9.3",
-			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-client/0.9.3/2531707a05b8d276de323cf52669bd2d052d29010774adf3d764e350aab1f400",
-			"integrity": "sha512-p6WAcWRW7SkIzk5AO6Kz4TgX5cDVcOu88WqJAx4ZMH4xaR/lgJQtNWnuNOrZAfGs3edAMyL7CU04CpOx6yeuOA==",
+			"version": "0.9.7",
+			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-client/0.9.7/75d6356f32fa7ccbfd299924678206a44d4c0cb6323795c70fbd02fa459b35cd",
+			"integrity": "sha512-FzuomJrX5brBwRwMDeandhqwGhIAMI7sJNWuxn7AY+KBnvnqQ3yhkw2gHFROWIAXufET+LXRo24I3HQesGR+/w==",
 			"license": "MIT",
 			"dependencies": {
 				"whatwg-fetch": "^3.6.2"
 			}
 		},
 		"node_modules/@searchspring/snap-controller": {
-			"version": "0.9.3",
-			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-controller/0.9.3/7a0c797a8e35f3330f276ad0f3222550c3027eb685874882ad09573dbf8013d9",
-			"integrity": "sha512-Eve5QQ5kOynHHi6I1EX45HOcBgTzOagGT9PIX+C4EnDnF9NJqQJLIMQnwwOnJdqjaIB+45gPBg4B35g1z9wGLQ==",
+			"version": "0.9.7",
+			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-controller/0.9.7/234fec67a22d55740be37a2cbffc395ed274bb1d16d244cca7135889570f54c1",
+			"integrity": "sha512-dW9wJmhKdBHJTq4YO+oEnE8p+yTIo9P2Lhk/NBXnnodO6Q3OcYnzx4aNJLK8JNWEcqAyQn2l4VIGocgreRaBzQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-toolbox": "^0.9.3",
+				"@searchspring/snap-toolbox": "^0.9.7",
 				"deepmerge": "^4.2.2"
 			}
 		},
 		"node_modules/@searchspring/snap-event-manager": {
-			"version": "0.9.3",
-			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-event-manager/0.9.3/f701e0a43866a572a29f9554b19bbfb07855d4214a78c33f63e5e71e2fc9b37d",
-			"integrity": "sha512-Btaicl7VACIXYXLm38RODwhO6fDlHObSqmwz/uxvKo91oFaE+IP8WXJkJWLXjyC++qSQEje6bZ+E7GS3Jj5Qlg==",
+			"version": "0.9.7",
+			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-event-manager/0.9.7/96edff2ace9df15948a6d4dcab79225e963636e6dc6d4f0c13ffd7fac0034361",
+			"integrity": "sha512-+5bCJRDhkvMmaYtAybcfvSEx5xnF/3C2IDJksOfDGHzOVM0Hr2qulVVHdg6dhxqfm3FzximTi7TtkkO6iltr3A==",
 			"license": "MIT"
 		},
 		"node_modules/@searchspring/snap-logger": {
-			"version": "0.9.3",
-			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-logger/0.9.3/7add1619a863299324cb4b5bd1960aeded85d654bd36ee5ea4ac4d5f52ecf8fc",
-			"integrity": "sha512-G0t+WIBDhrn5Iv3u/r3rAEQQxi6TbUYBNOkayEC2cYZcpVcZwKe2SsQ+RBbdQFLkZfynFdwqxwiAS7bR2BkUaw==",
+			"version": "0.9.7",
+			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-logger/0.9.7/87316d32ea2b8b9c2b9c441bb16d21b49bfe372e013a4cd44c3f35b4b18a0e84",
+			"integrity": "sha512-9rpBcHq8tz1kIaXaKY9bn9kvzmpmS5iwWP+uANPm13k6UldKDXRA6BhAGkEimLIX7fX7TRSZKasvBxKjkryBVw==",
 			"license": "MIT"
 		},
 		"node_modules/@searchspring/snap-preact": {
-			"version": "0.9.3",
-			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-preact/0.9.3/f07075a8da82cb661c271e378e140ffd967cdfefa1b2188cc745cde5a6952b59",
-			"integrity": "sha512-3WuY6DPz93z31A5cF9qW76Tb4A1DP7ZHFQp6QBmMzJoRUe3pi6H4s8WhLjep9fUeayIgxzrQEEOYeyqly8guWw==",
+			"version": "0.9.7",
+			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-preact/0.9.7/d40c58ca382b97d6f503cabe511a6b907719f949d5482ba5cc92f731ebb1bb99",
+			"integrity": "sha512-ka/K8bgyeyMErcet7BnZeV+ml0bXFsbpl3mkVW0kMKU0oQ8UKIUAg5C6BsgwYktepVNUNc7uSKwUf71G4YIKdQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-client": "^0.9.3",
-				"@searchspring/snap-controller": "^0.9.3",
-				"@searchspring/snap-event-manager": "^0.9.3",
-				"@searchspring/snap-logger": "^0.9.3",
-				"@searchspring/snap-profiler": "^0.9.3",
-				"@searchspring/snap-store-mobx": "^0.9.3",
-				"@searchspring/snap-toolbox": "^0.9.3",
-				"@searchspring/snap-tracker": "^0.9.3",
-				"@searchspring/snap-url-manager": "^0.9.3",
+				"@searchspring/snap-client": "^0.9.7",
+				"@searchspring/snap-controller": "^0.9.7",
+				"@searchspring/snap-event-manager": "^0.9.7",
+				"@searchspring/snap-logger": "^0.9.7",
+				"@searchspring/snap-profiler": "^0.9.7",
+				"@searchspring/snap-store-mobx": "^0.9.7",
+				"@searchspring/snap-toolbox": "^0.9.7",
+				"@searchspring/snap-tracker": "^0.9.7",
+				"@searchspring/snap-url-manager": "^0.9.7",
 				"deepmerge": "^4.2.2"
 			}
 		},
 		"node_modules/@searchspring/snap-preact-components": {
-			"version": "0.9.3",
-			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-preact-components/0.9.3/bfc1de0421db8bc32699f8243f6e9c3ec7d5a99f3ca9e65166ce58523dae0fda",
-			"integrity": "sha512-0BkNI5MltbKJUjjPjK6fvUXcEVIVfEgGLVmpBF19hJP708m1ttxD078H6pp2it3LGSngfssSqZ4nOJef+KwHmw==",
+			"version": "0.9.7",
+			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-preact-components/0.9.7/396f9f366552a0a328b25ae0756699b656f151912ffdf112a4f4f506c3627108",
+			"integrity": "sha512-MMCRN7g17uHRJI+XE182nqKbQAAss1O+D0vqJaszBdB8W847kwtYWYubZMNl5bIGKH2411XtXCNhct3jCN1umw==",
 			"license": "MIT",
 			"dependencies": {
 				"@emotion/react": "^11.4.1",
-				"@searchspring/snap-preact": "^0.9.3",
-				"@searchspring/snap-toolbox": "^0.9.3",
+				"@searchspring/snap-preact": "^0.9.7",
+				"@searchspring/snap-toolbox": "^0.9.7",
 				"classnames": "^2.3.1",
 				"mobx-react-lite": "^3.2.1",
 				"react-ranger": "^2.1.0",
@@ -2080,43 +2080,43 @@
 			}
 		},
 		"node_modules/@searchspring/snap-profiler": {
-			"version": "0.9.3",
-			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-profiler/0.9.3/5881584ace62f9824927721a99cb8c2a1c8e1d8ddd799ead41925ea6b061f75c",
-			"integrity": "sha512-YvSf9wbl8KjGJwqgjoFUs+uIAVR+Vx3/Etxqfha+Qa07W4zgYRs4zo+7aboJ1pqD2SB6FeAZTRnGLk1xeV7G9A==",
+			"version": "0.9.7",
+			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-profiler/0.9.7/0e889ab1512afcfa4767231c6fe7b096ce8830d6be715a290e479d29a462ea99",
+			"integrity": "sha512-h4luxEKPMkpROHtgOIL1dZnbecpo2X82dAlgkLwobOzR7pZbYWiBXju041vEUCdVHU+ZW3OzKxN5FrMDII4iYw==",
 			"license": "MIT"
 		},
 		"node_modules/@searchspring/snap-store-mobx": {
-			"version": "0.9.3",
-			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-store-mobx/0.9.3/b87caccfca9b974787d1ecbe9d230f767bd0906dbade8909694a79b932ea5b10",
-			"integrity": "sha512-tzkAcb/EXuuF0P4on/wYjBsWy7GmXpKGZfNBtOrgXo9YYHwfswmQ9wYoUPCLwwbqas95/Ffc7KUMti937HvhyQ==",
+			"version": "0.9.7",
+			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-store-mobx/0.9.7/3f4e2e42df7624b5a169c104b098f24e2b35feb6ed702cc307aef527c12a2135",
+			"integrity": "sha512-DV2uV1A61pn0WUz36Krbc2hd07qrWAMoUSkYjO7vEWE+M49NSMQmLKzHSxZhLN0+hjl218k66fVPOPIyCvTPtQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-toolbox": "^0.9.3",
+				"@searchspring/snap-toolbox": "^0.9.7",
 				"mobx": "^6.3.3"
 			}
 		},
 		"node_modules/@searchspring/snap-toolbox": {
-			"version": "0.9.3",
-			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-toolbox/0.9.3/905e73c99eacc58be6fbf5fc9aec3b488a07d5a568358a57ed402d7b12c78008",
-			"integrity": "sha512-JRmEzfx3G84wY3XGED73OHs6qTy++LpISwkBkikwOy4TPOYCQJfVIMCqPcC8yVk/UHrCZXnB37S+aABWrVYzBA==",
+			"version": "0.9.7",
+			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-toolbox/0.9.7/0b16436780458119e9adc5e88c0d9b1557a3dc42427547d87e310fc9ba7c57e5",
+			"integrity": "sha512-B4twCHphmwynSAKkYekDlOBVkCO2nhCMixdyVSWWbIbRwkabjn6nuyAwNKblL7tSD8e7MoaqAOJZ3toPGzLcjA==",
 			"license": "MIT"
 		},
 		"node_modules/@searchspring/snap-tracker": {
-			"version": "0.9.3",
-			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-tracker/0.9.3/d7114c9e78ac563fe8ca6ec88bf51af536c4b3347b5a7fa3285e5c70b2a079fd",
-			"integrity": "sha512-tMvnhh0b1ocI1ud7oUM5OZRMNlwiRMnM/nytXzMi5NcVCoytq19f8oeQia9mUXKv8MG3FFSKrRnxTfdf9NPJOQ==",
+			"version": "0.9.7",
+			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-tracker/0.9.7/b53c5005d38b344ba45183e8a43961ebde013265ff3c41e9ab5892aaa4b17b72",
+			"integrity": "sha512-WWPvlZQE6JquXvnR7KD3vdJ+Mj32z+p2vbNEDlhAvKZ8C22KMvyaKgBYjZ3upxQmhgns0MJ69eZl6vnjQr5Sww==",
 			"license": "MIT",
 			"dependencies": {
-				"@searchspring/snap-store-mobx": "^0.9.3",
-				"@searchspring/snap-toolbox": "^0.9.3",
+				"@searchspring/snap-store-mobx": "^0.9.7",
+				"@searchspring/snap-toolbox": "^0.9.7",
 				"deepmerge": "^4.2.2",
 				"uuid": "^8.3.2"
 			}
 		},
 		"node_modules/@searchspring/snap-url-manager": {
-			"version": "0.9.3",
-			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-url-manager/0.9.3/9c2237d2904db34dc18d640dbdededf13f866dd30261125669e756c68b2d4241",
-			"integrity": "sha512-c2bLNS0G/aNYD9NFGWsll0263L+cQYFozqgGQHSTIffo4Fg4ow5GIa3Cjw8QFyWZMxmEFWF8BDR7Q1qXKg1KVw==",
+			"version": "0.9.7",
+			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-url-manager/0.9.7/d3069debc58ee1934c3afbeb08183dca4ecc92533e4c4979aaf557b7c3f04967",
+			"integrity": "sha512-lscXuQGqURPW2NlbQYkHKHakvxRq9ir3nfuu6117ZeLUAw6t/7iwfcOF0jwywK3rxNMoe9UgNYoMoLUWWO/3ag==",
 			"license": "MIT",
 			"dependencies": {
 				"deepmerge": "^4.2.2",
@@ -2145,9 +2145,9 @@
 			}
 		},
 		"node_modules/@types/eslint": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.0.tgz",
-			"integrity": "sha512-07XlgzX0YJUn4iG1ocY4IX9DzKSmMGUs6ESKlxWhZRaa0fatIWaHWUVapcuGa8r5HFnTqzj+4OCjd5f7EZ/i/A==",
+			"version": "7.28.1",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.1.tgz",
+			"integrity": "sha512-XhZKznR3i/W5dXqUhgU9fFdJekufbeBd5DALmkuXoeFcjbQcPk+2cL+WLHf6Q81HWAnM2vrslIHpGVyCAviRwg==",
 			"dev": true,
 			"dependencies": {
 				"@types/estree": "*",
@@ -2192,9 +2192,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "14.17.17",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.17.tgz",
-			"integrity": "sha512-niAjcewgEYvSPCZm3OaM9y6YQrL2SEPH9PymtE6fuZAvFiP6ereCcvApGl2jKTq7copTIguX3PBvfP08LN4LvQ==",
+			"version": "14.17.22",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.22.tgz",
+			"integrity": "sha512-6Mgu9YWd8j0dk9M8V9+5w6ktqIFCcn/fFXAVIDFk/niAOFiOiz4GeFAMWYAQjKrcsASbFqMkqR8/Y2wuVCAkNg==",
 			"dev": true
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -2216,9 +2216,9 @@
 			"dev": true
 		},
 		"node_modules/@types/sinonjs__fake-timers": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.3.tgz",
-			"integrity": "sha512-E1dU4fzC9wN2QK2Cr1MLCfyHM8BoNnRFvuf45LYMPNDA+WqbNzC45S4UzPxvp1fFJ1rvSGU0bPvdd35VLmXG8g==",
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.4.tgz",
+			"integrity": "sha512-IFQTJARgMUBF+xVd2b+hIgXWrZEjND3vJtRCvIelcFB5SIXfjV4bOHbHJ0eXKh+0COrBRc8MqteKAz/j88rE0A==",
 			"dev": true
 		},
 		"node_modules/@types/sizzle": {
@@ -2384,9 +2384,9 @@
 			}
 		},
 		"node_modules/@webpack-cli/configtest": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.4.tgz",
-			"integrity": "sha512-cs3XLy+UcxiP6bj0A6u7MLLuwdXJ1c3Dtc0RkKg+wiI1g/Ti1om8+/2hc2A2B60NbBNAbMgyBMHvyymWm/j4wQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
+			"integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
 			"dev": true,
 			"peerDependencies": {
 				"webpack": "4.x.x || 5.x.x",
@@ -2394,9 +2394,9 @@
 			}
 		},
 		"node_modules/@webpack-cli/info": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.3.0.tgz",
-			"integrity": "sha512-ASiVB3t9LOKHs5DyVUcxpraBXDOKubYu/ihHhU+t1UPpxsivg6Od2E2qU4gJCekfEddzRBzHhzA/Acyw/mlK/w==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
+			"integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
 			"dev": true,
 			"dependencies": {
 				"envinfo": "^7.7.3"
@@ -2406,9 +2406,9 @@
 			}
 		},
 		"node_modules/@webpack-cli/serve": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.5.2.tgz",
-			"integrity": "sha512-vgJ5OLWadI8aKjDlOH3rb+dYyPd2GTZuQC/Tihjct6F9GpXGZINo3Y/IVuZVTM1eDQB+/AOsjPUWH/WySDaXvw==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
+			"integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
 			"dev": true,
 			"peerDependencies": {
 				"webpack-cli": "4.x.x"
@@ -2528,62 +2528,12 @@
 			}
 		},
 		"node_modules/ansi-align": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
-			"integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+			"integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
 			"dev": true,
 			"dependencies": {
-				"string-width": "^3.0.0"
-			}
-		},
-		"node_modules/ansi-align/node_modules/ansi-regex": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/ansi-align/node_modules/emoji-regex": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-			"dev": true
-		},
-		"node_modules/ansi-align/node_modules/is-fullwidth-code-point": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/ansi-align/node_modules/string-width": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-			"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-			"dev": true,
-			"dependencies": {
-				"emoji-regex": "^7.0.1",
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^5.1.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/ansi-align/node_modules/strip-ansi": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=6"
+				"string-width": "^4.1.0"
 			}
 		},
 		"node_modules/ansi-colors": {
@@ -2708,16 +2658,16 @@
 			"dev": true
 		},
 		"node_modules/array-includes": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
-			"integrity": "sha512-gcem1KlBU7c9rB+Rq8/3PPKsK2kjqeEBa3bD5kkQo4nYlOHQCJqIJFqBXDEfwaRuYTT4E+FxA9xez7Gf/e3Q7A==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
+			"integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.0-next.2",
+				"es-abstract": "^1.19.1",
 				"get-intrinsic": "^1.1.1",
-				"is-string": "^1.0.5"
+				"is-string": "^1.0.7"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -2736,15 +2686,14 @@
 			}
 		},
 		"node_modules/array.prototype.flatmap": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.4.tgz",
-			"integrity": "sha512-r9Z0zYoxqHz60vvQbWEdXIEtCwHF0yxaWfno9qzXeNHvfyl3BZqygmGzb84dsubyaXLH4husF+NFgMSdpZhk2Q==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.5.tgz",
+			"integrity": "sha512-08u6rVyi1Lj7oqWbS9nUxliETrtIROT4XGTA4D/LWGten6E3ocm7cy9SIrmNHOL5XVbVuckUp3X6Xyg8/zpvHA==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.0-next.1",
-				"function-bind": "^1.1.1"
+				"es-abstract": "^1.19.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -2907,13 +2856,13 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs3": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.4.tgz",
-			"integrity": "sha512-z3HnJE5TY/j4EFEa/qpQMSbcUJZ5JQi+3UFjXzn6pQCmIKc5Ug5j98SuYyH+m4xQnvKlMDIW4plLfgyVnd0IcQ==",
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.5.tgz",
+			"integrity": "sha512-ninF5MQNwAX9Z7c9ED+H2pGt1mXdP4TqzlHKyPIYmJIYz0N+++uwdM7RnJukklhzJ54Q84vA4ZJkgs7lu5vqcw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-define-polyfill-provider": "^0.2.2",
-				"core-js-compat": "^3.14.0"
+				"core-js-compat": "^3.16.2"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
@@ -3171,16 +3120,16 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.17.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
-			"integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
+			"version": "4.17.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.3.tgz",
+			"integrity": "sha512-59IqHJV5VGdcJZ+GZ2hU5n4Kv3YiASzW6Xk5g9tf5a/MAzGeFwgGWU39fVzNIOVcgB3+Gp+kiQu0HEfTVU/3VQ==",
 			"devOptional": true,
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001254",
-				"colorette": "^1.3.0",
-				"electron-to-chromium": "^1.3.830",
+				"caniuse-lite": "^1.0.30001264",
+				"electron-to-chromium": "^1.3.857",
 				"escalade": "^3.1.1",
-				"node-releases": "^1.1.75"
+				"node-releases": "^1.1.77",
+				"picocolors": "^0.2.1"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -3308,9 +3257,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001258",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001258.tgz",
-			"integrity": "sha512-RBByOG6xWXUp0CR2/WU2amXz3stjKpSl5J1xU49F1n2OxD//uBZO4wCKUiG+QMGf7CHGfDDcqoKriomoGVxTeA==",
+			"version": "1.0.30001265",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz",
+			"integrity": "sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw==",
 			"devOptional": true,
 			"funding": {
 				"type": "opencollective",
@@ -3386,9 +3335,9 @@
 			}
 		},
 		"node_modules/chrome-launcher": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.14.0.tgz",
-			"integrity": "sha512-W//HpflaW6qBGrmuskup7g+XJZN6w03ko9QSIe5CtcTal2u0up5SeReK3Ll1Why4Ey8dPkv8XSodZyHPnGbVHQ==",
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.14.1.tgz",
+			"integrity": "sha512-iQ4s61NkIyaozsE2VKg1Vu3YGdD3JGw+fBBrt3FYJi7uflO9TvlTLW4MUq0fq3EKGhzB/QHPd5AsLb14+9++JQ==",
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*",
@@ -3559,7 +3508,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
 			"integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
-			"devOptional": true
+			"dev": true
 		},
 		"node_modules/colors": {
 			"version": "1.4.0",
@@ -3736,9 +3685,9 @@
 			"dev": true
 		},
 		"node_modules/core-js": {
-			"version": "3.17.3",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.17.3.tgz",
-			"integrity": "sha512-lyvajs+wd8N1hXfzob1LdOCCHFU4bGMbqqmLn1Q4QlCpDqWPpGf+p0nj+LNrvDDG33j0hZXw2nsvvVpHysxyNw==",
+			"version": "3.18.2",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.18.2.tgz",
+			"integrity": "sha512-zNhPOUoSgoizoSQFdX1MeZO16ORRb9FFQLts8gSYbZU5FcgXhp24iMWMxnOQo5uIaIG7/6FA/IqJPwev1o9ZXQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"funding": {
@@ -3747,12 +3696,12 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.17.3",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.17.3.tgz",
-			"integrity": "sha512-+in61CKYs4hQERiADCJsdgewpdl/X0GhEX77pjKgbeibXviIt2oxEjTc8O2fqHX8mDdBrDvX8MYD/RYsBv4OiA==",
+			"version": "3.18.2",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.18.2.tgz",
+			"integrity": "sha512-25VJYCJtGjZwLguj7d66oiHfmnVw3TMOZ0zV8DyMJp/aeQ3OjR519iOOeck08HMyVVRAqXxafc2Hl+5QstJrsQ==",
 			"dev": true,
 			"dependencies": {
-				"browserslist": "^4.17.0",
+				"browserslist": "^4.17.3",
 				"semver": "7.0.0"
 			},
 			"funding": {
@@ -3830,9 +3779,9 @@
 			"dev": true
 		},
 		"node_modules/css-loader": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.2.0.tgz",
-			"integrity": "sha512-/rvHfYRjIpymZblf49w8jYcRo2y9gj6rV8UroHGmBxKrIyGLokpycyKzp9OkitvqT29ZSpzJ0Ic7SpnJX3sC8g==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.4.0.tgz",
+			"integrity": "sha512-Dlt6qfsxI/w1vU0r8qDd4BtMPxWqJeY5qQU7SmmZfvbpe6Xl18McO4GhyaMLns24Y2VNPiZwJPQ8JSbg4qvQLw==",
 			"dev": true,
 			"dependencies": {
 				"icss-utils": "^5.1.0",
@@ -3903,9 +3852,9 @@
 			"integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw=="
 		},
 		"node_modules/cypress": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/cypress/-/cypress-8.4.0.tgz",
-			"integrity": "sha512-RtVgGFR06ikyMaq/VqapeqOjGaIA42PpK7F0qe1MCiFArfUuJECsLmeYaOA+1TlmNUgJNMSF5fWKkZIJr5Uc7w==",
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/cypress/-/cypress-8.6.0.tgz",
+			"integrity": "sha512-F7qEK/6Go5FsqTueR+0wEw2vOVKNgk5847Mys8vsWkzPoEKdxs+7N9Y1dit+zhaZCLtMPyrMwjfA53ZFy+lSww==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -3943,6 +3892,7 @@
 				"minimist": "^1.2.5",
 				"ospath": "^1.2.2",
 				"pretty-bytes": "^5.6.0",
+				"proxy-from-env": "1.0.0",
 				"ramda": "~0.27.1",
 				"request-progress": "^3.0.0",
 				"supports-color": "^8.1.1",
@@ -4400,9 +4350,9 @@
 			"dev": true
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.3.842",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.842.tgz",
-			"integrity": "sha512-P/nDMPIYdb2PyqCQwhTXNi5JFjX1AsDVR0y6FrHw752izJIAJ+Pn5lugqyBq4tXeRSZBMBb2ZGvRGB1djtELEQ==",
+			"version": "1.3.866",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.866.tgz",
+			"integrity": "sha512-iYze6TpDXWxk+sfcpUUdTs6Pv/3kG45Pnjer2DxEeFw0N08bZeNLuz97s2lMgy8yObon48o0WHY2Bkg3xuAPOA==",
 			"devOptional": true
 		},
 		"node_modules/emoji-regex": {
@@ -4439,9 +4389,9 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.8.2",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz",
-			"integrity": "sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==",
+			"version": "5.8.3",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
+			"integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
 			"dev": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
@@ -4494,9 +4444,9 @@
 			}
 		},
 		"node_modules/es-abstract": {
-			"version": "1.18.6",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
-			"integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+			"integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
@@ -4510,7 +4460,9 @@
 				"is-callable": "^1.2.4",
 				"is-negative-zero": "^2.0.1",
 				"is-regex": "^1.1.4",
+				"is-shared-array-buffer": "^1.0.1",
 				"is-string": "^1.0.7",
+				"is-weakref": "^1.0.1",
 				"object-inspect": "^1.11.0",
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.2",
@@ -4526,9 +4478,9 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.7.1.tgz",
-			"integrity": "sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw==",
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
 			"dev": true
 		},
 		"node_modules/es-to-primitive": {
@@ -4639,23 +4591,24 @@
 			}
 		},
 		"node_modules/eslint-plugin-react": {
-			"version": "7.25.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.25.2.tgz",
-			"integrity": "sha512-elx4585wgmryanJK4C5IoSKQyVZ+e7H0t2JOOtJNBql0cuercvSShvRReuLBbfx8687yW5yv+UL7pXwMsd6adQ==",
+			"version": "7.26.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
+			"integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
 			"dev": true,
 			"dependencies": {
 				"array-includes": "^3.1.3",
 				"array.prototype.flatmap": "^1.2.4",
 				"doctrine": "^2.1.0",
 				"estraverse": "^5.2.0",
-				"has": "^1.0.3",
 				"jsx-ast-utils": "^2.4.1 || ^3.0.0",
 				"minimatch": "^3.0.4",
 				"object.entries": "^1.1.4",
 				"object.fromentries": "^2.0.4",
+				"object.hasown": "^1.0.0",
 				"object.values": "^1.1.4",
 				"prop-types": "^15.7.2",
 				"resolve": "^2.0.0-next.3",
+				"semver": "^6.3.0",
 				"string.prototype.matchall": "^4.0.5"
 			},
 			"engines": {
@@ -4957,9 +4910,9 @@
 			}
 		},
 		"node_modules/eventemitter2": {
-			"version": "6.4.4",
-			"resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.4.tgz",
-			"integrity": "sha512-HLU3NDY6wARrLCEwyGKRBvuWYyvW6mHYv72SJJAH3iJN3a6eVUvkjFkcxah1bcTgGVBBrFdIopBJPhCQFMLyXw==",
+			"version": "6.4.5",
+			"resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.5.tgz",
+			"integrity": "sha512-bXE7Dyc1i6oQElDG0jMRZJrRAn9QR2xyyFGmBdZleNmyQX0FqGYmhZIrIrpPfm/w//LTo4tVQGOGQcGCb5q9uw==",
 			"dev": true
 		},
 		"node_modules/eventemitter3": {
@@ -5668,9 +5621,9 @@
 			}
 		},
 		"node_modules/glob": {
-			"version": "7.1.7",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-			"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
 			"dev": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
@@ -5770,6 +5723,26 @@
 			},
 			"engines": {
 				"node": ">= 0.10"
+			}
+		},
+		"node_modules/globule/node_modules/glob": {
+			"version": "7.1.7",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+			"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+			"dev": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/got": {
@@ -6188,9 +6161,9 @@
 			}
 		},
 		"node_modules/import-local": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
-			"integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.3.tgz",
+			"integrity": "sha512-bE9iaUY3CXH8Cwfan/abDKAxe1KGT9kyGsBPqf6DMK/z0a2OzAsrukeYNgIH6cH5Xr452jb1TUL8rSfCLjZ9uA==",
 			"dev": true,
 			"dependencies": {
 				"pkg-dir": "^4.2.0",
@@ -6429,9 +6402,9 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
-			"integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.7.0.tgz",
+			"integrity": "sha512-ByY+tjCciCr+9nLryBYcSD50EOGWt95c7tIsKTG1J2ixKKXPvF7Ej3AVd+UfDydAJom3biBGDBALaO79ktwgEQ==",
 			"dev": true,
 			"dependencies": {
 				"has": "^1.0.3"
@@ -6489,9 +6462,9 @@
 			}
 		},
 		"node_modules/is-glob": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
 			"dev": true,
 			"dependencies": {
 				"is-extglob": "^2.1.1"
@@ -6646,6 +6619,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-shared-array-buffer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+			"integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-stream": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -6706,6 +6688,18 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/is-weakref": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
+			"integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-wsl": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -6752,9 +6746,9 @@
 			"dev": true
 		},
 		"node_modules/jest-worker": {
-			"version": "27.2.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.2.0.tgz",
-			"integrity": "sha512-laB0ZVIBz+voh/QQy9dmUuuDsadixeerrKqyVpgPz+CCWiOYjOBabUXHIXZhsdvkWbLqSHbgkAHWl5cg24Q6RA==",
+			"version": "27.2.5",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.2.5.tgz",
+			"integrity": "sha512-HTjEPZtcNKZ4LnhSp02NEH4vE+5OpJ0EsOWYvGQpHgUMLngydESAAMH5Wd/asPf29+XUDQZszxpLg1BkIIA2aw==",
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*",
@@ -7002,9 +6996,9 @@
 			}
 		},
 		"node_modules/lighthouse": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-8.4.0.tgz",
-			"integrity": "sha512-O4DE/UFvn63iu1hRNFRYY+ZzEHfN463fBSxUuux4cFXRd5c398FgL6VDiZgmy28jQ9U6lYmsKZW1xLcWLEuO+g==",
+			"version": "8.5.1",
+			"resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-8.5.1.tgz",
+			"integrity": "sha512-phe3g77N5AE5pf5TARUBb9uHLvvzwpd2z/S0G+6KrC5ShEe2laSxkiiTLo/jYxsrmy5kL7qohVztdOuafy4HGQ==",
 			"dev": true,
 			"dependencies": {
 				"axe-core": "4.2.3",
@@ -7094,25 +7088,25 @@
 			"dev": true
 		},
 		"node_modules/lint-staged": {
-			"version": "11.1.2",
-			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-11.1.2.tgz",
-			"integrity": "sha512-6lYpNoA9wGqkL6Hew/4n1H6lRqF3qCsujVT0Oq5Z4hiSAM7S6NksPJ3gnr7A7R52xCtiZMcEUNNQ6d6X5Bvh9w==",
+			"version": "11.2.3",
+			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-11.2.3.tgz",
+			"integrity": "sha512-Tfmhk8O2XFMD25EswHPv+OYhUjsijy5D7liTdxeXvhG2rsadmOLFtyj8lmlfoFFXY8oXWAIOKpoI+lJe1DB1mw==",
 			"dev": true,
 			"dependencies": {
-				"chalk": "^4.1.1",
-				"cli-truncate": "^2.1.0",
-				"commander": "^7.2.0",
-				"cosmiconfig": "^7.0.0",
-				"debug": "^4.3.1",
+				"cli-truncate": "2.1.0",
+				"colorette": "^1.4.0",
+				"commander": "^8.2.0",
+				"cosmiconfig": "^7.0.1",
+				"debug": "^4.3.2",
 				"enquirer": "^2.3.6",
-				"execa": "^5.0.0",
-				"listr2": "^3.8.2",
-				"log-symbols": "^4.1.0",
+				"execa": "^5.1.1",
+				"listr2": "^3.12.2",
 				"micromatch": "^4.0.4",
 				"normalize-path": "^3.0.0",
 				"please-upgrade-node": "^3.2.0",
 				"string-argv": "0.3.1",
-				"stringify-object": "^3.3.0"
+				"stringify-object": "3.3.0",
+				"supports-color": "8.1.1"
 			},
 			"bin": {
 				"lint-staged": "bin/lint-staged.js"
@@ -7121,62 +7115,13 @@
 				"url": "https://opencollective.com/lint-staged"
 			}
 		},
-		"node_modules/lint-staged/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/lint-staged/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/lint-staged/node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/lint-staged/node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true
-		},
 		"node_modules/lint-staged/node_modules/commander": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-8.2.0.tgz",
+			"integrity": "sha512-LLKxDvHeL91/8MIyTAD5BFMNtoIwztGPMiM/7Bl8rIPmHCZXRxmSWr91h57dpOpnQ6jIUqEWdXE/uBYMfiVZDA==",
 			"dev": true,
 			"engines": {
-				"node": ">= 10"
+				"node": ">= 12"
 			}
 		},
 		"node_modules/lint-staged/node_modules/execa": {
@@ -7233,21 +7178,24 @@
 			}
 		},
 		"node_modules/lint-staged/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
 			"dev": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
 		"node_modules/listr2": {
-			"version": "3.12.1",
-			"resolved": "https://registry.npmjs.org/listr2/-/listr2-3.12.1.tgz",
-			"integrity": "sha512-oB1DlXlCzGPbvWhqYBZUQEPJKqsmebQWofXG6Mpbe3uIvoNl8mctBEojyF13ZyqwQ91clCWXpwsWp+t98K4FOQ==",
+			"version": "3.12.2",
+			"resolved": "https://registry.npmjs.org/listr2/-/listr2-3.12.2.tgz",
+			"integrity": "sha512-64xC2CJ/As/xgVI3wbhlPWVPx0wfTqbUAkpb7bjDi0thSWMqrf07UFhrfsGoo8YSXmF049Rp9C0cjLC8rZxK9A==",
 			"dev": true,
 			"dependencies": {
 				"cli-truncate": "^2.1.0",
@@ -7588,9 +7536,9 @@
 			}
 		},
 		"node_modules/map-obj": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
-			"integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=8"
@@ -7626,9 +7574,9 @@
 			}
 		},
 		"node_modules/memfs": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/memfs/-/memfs-3.2.4.tgz",
-			"integrity": "sha512-2mDCPhuduRPOxlfgsXF9V+uqC6Jgz8zt/bNe4d4W7d5f6pCzHrWkxLNr17jKGXd4+j2kQNsAG2HARPnt74sqVQ==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/memfs/-/memfs-3.3.0.tgz",
+			"integrity": "sha512-BEE62uMfKOavX3iG7GYX43QJ+hAeeWnwIAuJ/R6q96jaMtiLzhsxHJC8B1L7fK7Pt/vXDRwb3SG/yBpNGDPqzg==",
 			"dev": true,
 			"dependencies": {
 				"fs-monkey": "1.0.3"
@@ -7737,21 +7685,21 @@
 			}
 		},
 		"node_modules/mime-db": {
-			"version": "1.49.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
-			"integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==",
+			"version": "1.50.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
+			"integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==",
 			"dev": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
 		},
 		"node_modules/mime-types": {
-			"version": "2.1.32",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
-			"integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
+			"version": "2.1.33",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
+			"integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==",
 			"dev": true,
 			"dependencies": {
-				"mime-db": "1.49.0"
+				"mime-db": "1.50.0"
 			},
 			"engines": {
 				"node": ">= 0.6"
@@ -7945,9 +7893,9 @@
 			"dev": true
 		},
 		"node_modules/nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.29.tgz",
+			"integrity": "sha512-dW2pUSGZ8ZnCFIlBIA31SV8huOGCHb6OwzVCc7A69rb/a+SgPBwfmLvK5TKQ3INPbRkcI8a/Owo0XbiTNH19wg==",
 			"dev": true,
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
@@ -8026,9 +7974,9 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "1.1.75",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
-			"integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
+			"version": "1.1.77",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.77.tgz",
+			"integrity": "sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ==",
 			"devOptional": true
 		},
 		"node_modules/node-sass": {
@@ -8282,29 +8230,28 @@
 			}
 		},
 		"node_modules/object.entries": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.4.tgz",
-			"integrity": "sha512-h4LWKWE+wKQGhtMjZEBud7uLGhqyLwj8fpHOarZhD2uY3C9cRtk57VQ89ke3moByLXMedqs3XCHzyb4AmA2DjA==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
+			"integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.2"
+				"es-abstract": "^1.19.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
 			}
 		},
 		"node_modules/object.fromentries": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.4.tgz",
-			"integrity": "sha512-EsFBshs5RUUpQEY1D4q/m59kMfz4YJvxuNCJcv/jWwOJr34EaVnG11ZrZa0UHB3wnzV1wx8m58T4hQL8IuNXlQ==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
+			"integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.0-next.2",
-				"has": "^1.0.3"
+				"es-abstract": "^1.19.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -8313,15 +8260,28 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/object.hasown": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.0.tgz",
+			"integrity": "sha512-MhjYRfj3GBlhSkDHo6QmvgjRLXQ2zndabdf3nX0yTyZK9rPfxb6uRpAac8HXNLy1GpqWtZ81Qh4v3uOls2sRAg==",
+			"dev": true,
+			"dependencies": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.19.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/object.values": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
-			"integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
+			"integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.2"
+				"es-abstract": "^1.19.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -8663,6 +8623,12 @@
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
 			"dev": true
 		},
+		"node_modules/picocolors": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+			"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+			"devOptional": true
+		},
 		"node_modules/picomatch": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -8750,13 +8716,13 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.3.6",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
-			"integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
+			"version": "8.3.9",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.9.tgz",
+			"integrity": "sha512-f/ZFyAKh9Dnqytx5X62jgjhhzttjZS7hMsohcI7HEI5tjELX/HxCy3EFhsRxyzGvrzFF+82XPvCS8T9TFleVJw==",
 			"dev": true,
 			"dependencies": {
-				"colorette": "^1.2.2",
-				"nanoid": "^3.1.23",
+				"nanoid": "^3.1.28",
+				"picocolors": "^0.2.1",
 				"source-map-js": "^0.6.2"
 			},
 			"engines": {
@@ -8846,9 +8812,9 @@
 			"dev": true
 		},
 		"node_modules/preact": {
-			"version": "10.5.14",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.5.14.tgz",
-			"integrity": "sha512-KojoltCrshZ099ksUZ2OQKfbH66uquFoxHSbnwKbTJHeQNvx42EmC7wQVWNuDt6vC5s3nudRHFtKbpY4ijKlaQ==",
+			"version": "10.5.15",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.5.15.tgz",
+			"integrity": "sha512-5chK29n6QcJc3m1lVrKQSQ+V7K1Gb8HeQY6FViQ5AxCAEGu3DaHffWNDkC9+miZgsLvbvU9rxbV1qinGHMHzqA==",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/preact"
@@ -8942,6 +8908,12 @@
 			"engines": {
 				"node": ">= 0.10"
 			}
+		},
+		"node_modules/proxy-from-env": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+			"integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+			"dev": true
 		},
 		"node_modules/ps-list": {
 			"version": "7.2.0",
@@ -9836,9 +9808,9 @@
 			}
 		},
 		"node_modules/sass-loader": {
-			"version": "12.1.0",
-			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.1.0.tgz",
-			"integrity": "sha512-FVJZ9kxVRYNZTIe2xhw93n3xJNYZADr+q69/s98l9nTCrWASo+DR2Ot0s5xTKQDDEosUkatsGeHxcH4QBp5bSg==",
+			"version": "12.2.0",
+			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.2.0.tgz",
+			"integrity": "sha512-qducnp5vSV+8A8MZxuH6zV0MUg4MOVISScl2wDTCAn/2WJX+9Auxh92O/rnkdR2bvi5QxZBafnzkzRrWGZvm7w==",
 			"dev": true,
 			"dependencies": {
 				"klona": "^2.0.4",
@@ -10157,9 +10129,9 @@
 			}
 		},
 		"node_modules/signal-exit": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.4.tgz",
-			"integrity": "sha512-rqYhcAnZ6d/vTPGghdrw7iumdcbXpsk1b8IG/rz+VWV51DM0p7XCtMoJ3qhPLIbp3tvyt3pKRbaaEMZYpHto8Q==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
+			"integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
 			"dev": true
 		},
 		"node_modules/sirv": {
@@ -10462,28 +10434,28 @@
 			}
 		},
 		"node_modules/string-width": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-			"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
 			"dev": true,
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.0"
+				"strip-ansi": "^6.0.1"
 			},
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/string.prototype.matchall": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.5.tgz",
-			"integrity": "sha512-Z5ZaXO0svs0M2xd/6By3qpeKpLKd9mO4v4q3oMEQrk8Ck4xOD5d5XeBOOjGrmVZZ/AHB1S0CgG4N5r1G9N3E2Q==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz",
+			"integrity": "sha512-6WgDX8HmQqvEd7J+G6VtAahhsQIssiZ8zl7zKh1VDMFyL3hRTJP4FTNA3RbIp2TOQ9AYNDcc7e3fH0Qbup+DBg==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.2",
+				"es-abstract": "^1.19.1",
 				"get-intrinsic": "^1.1.1",
 				"has-symbols": "^1.0.2",
 				"internal-slot": "^1.0.3",
@@ -10544,12 +10516,12 @@
 			}
 		},
 		"node_modules/strip-ansi": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-			"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"dev": true,
 			"dependencies": {
-				"ansi-regex": "^5.0.0"
+				"ansi-regex": "^5.0.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -10589,9 +10561,9 @@
 			}
 		},
 		"node_modules/style-loader": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.2.1.tgz",
-			"integrity": "sha512-1k9ZosJCRFaRbY6hH49JFlRB0fVSbmnyq1iTPjNxUmGVjBNEmwrrHPenhlp+Lgo51BojHSf6pl2FcqYaN3PfVg==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.0.tgz",
+			"integrity": "sha512-szANub7ksJtQioJYtpbWwh1hUl99uK15n5HDlikeCRil/zYMZgSxucHddyF/4A3qJMUiAjPhFowrrQuNMA7jwQ==",
 			"dev": true,
 			"engines": {
 				"node": ">= 12.13.0"
@@ -10645,17 +10617,17 @@
 			}
 		},
 		"node_modules/table": {
-			"version": "6.7.1",
-			"resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
-			"integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
+			"version": "6.7.2",
+			"resolved": "https://registry.npmjs.org/table/-/table-6.7.2.tgz",
+			"integrity": "sha512-UFZK67uvyNivLeQbVtkiUs8Uuuxv24aSL4/Vil2PJVtMgU8Lx0CYkP12uCGa3kjyQzOSgV1+z9Wkb82fCGsO0g==",
 			"dev": true,
 			"dependencies": {
 				"ajv": "^8.0.1",
 				"lodash.clonedeep": "^4.5.0",
 				"lodash.truncate": "^4.4.2",
 				"slice-ansi": "^4.0.0",
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.0"
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1"
 			},
 			"engines": {
 				"node": ">=10.0.0"
@@ -10772,9 +10744,9 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.8.0.tgz",
-			"integrity": "sha512-f0JH+6yMpneYcRJN314lZrSwu9eKkUFEHLN/kNy8ceh8gaRiLgFPJqrB9HsXjhEGdv4e/ekjTOFxIlL6xlma8A==",
+			"version": "5.9.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.9.0.tgz",
+			"integrity": "sha512-h5hxa23sCdpzcye/7b8YqbE5OwKca/ni0RQz1uRX3tGh8haaGHqcuSqbGRybuAKNdntZ0mDgFNXPJ48xQ2RXKQ==",
 			"dev": true,
 			"dependencies": {
 				"commander": "^2.20.0",
@@ -11451,9 +11423,9 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.53.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.53.0.tgz",
-			"integrity": "sha512-RZ1Z3z3ni44snoWjfWeHFyzvd9HMVYDYC5VXmlYUT6NWgEOWdCNpad5Fve2CzzHoRED7WtsKe+FCyP5Vk4pWiQ==",
+			"version": "5.58.1",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.58.1.tgz",
+			"integrity": "sha512-4Z/dmbTU+VmkCb2XNgW7wkE5TfEcSooclprn/UEuVeAkwHhn07OcgUsyaKHGtCY/VobjnsYBlyhKeMLiSoOqPg==",
 			"dev": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.0",
@@ -11465,8 +11437,8 @@
 				"acorn-import-assertions": "^1.7.6",
 				"browserslist": "^4.14.5",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.8.0",
-				"es-module-lexer": "^0.7.1",
+				"enhanced-resolve": "^5.8.3",
+				"es-module-lexer": "^0.9.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
@@ -11498,15 +11470,15 @@
 			}
 		},
 		"node_modules/webpack-bundle-analyzer": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.4.2.tgz",
-			"integrity": "sha512-PIagMYhlEzFfhMYOzs5gFT55DkUdkyrJi/SxJp8EF3YMWhS+T9vvs2EoTetpk5qb6VsCq02eXTlRDOydRhDFAQ==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.5.0.tgz",
+			"integrity": "sha512-GUMZlM3SKwS8Z+CKeIFx7CVoHn3dXFcUAjT/dcZQQmfSZGvitPfMob2ipjai7ovFFqPvTqkEZ/leL4O0YOdAYQ==",
 			"dev": true,
 			"dependencies": {
 				"acorn": "^8.0.4",
 				"acorn-walk": "^8.0.0",
 				"chalk": "^4.1.0",
-				"commander": "^6.2.0",
+				"commander": "^7.2.0",
 				"gzip-size": "^6.0.0",
 				"lodash": "^4.17.20",
 				"opener": "^1.5.2",
@@ -11582,12 +11554,12 @@
 			"dev": true
 		},
 		"node_modules/webpack-bundle-analyzer/node_modules/commander": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
 			"dev": true,
 			"engines": {
-				"node": ">= 6"
+				"node": ">= 10"
 			}
 		},
 		"node_modules/webpack-bundle-analyzer/node_modules/has-flag": {
@@ -11612,16 +11584,16 @@
 			}
 		},
 		"node_modules/webpack-cli": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.8.0.tgz",
-			"integrity": "sha512-+iBSWsX16uVna5aAYN6/wjhJy1q/GKk4KjKvfg90/6hykCTSgozbfz5iRgDTSJt/LgSbYxdBX3KBHeobIs+ZEw==",
+			"version": "4.9.0",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.0.tgz",
+			"integrity": "sha512-n/jZZBMzVEl4PYIBs+auy2WI0WTQ74EnJDiyD98O2JZY6IVIHJNitkYp/uTXOviIOMfgzrNvC9foKv/8o8KSZw==",
 			"dev": true,
 			"dependencies": {
 				"@discoveryjs/json-ext": "^0.5.0",
-				"@webpack-cli/configtest": "^1.0.4",
-				"@webpack-cli/info": "^1.3.0",
-				"@webpack-cli/serve": "^1.5.2",
-				"colorette": "^1.2.1",
+				"@webpack-cli/configtest": "^1.1.0",
+				"@webpack-cli/info": "^1.4.0",
+				"@webpack-cli/serve": "^1.6.0",
+				"colorette": "^2.0.14",
 				"commander": "^7.0.0",
 				"execa": "^5.0.0",
 				"fastest-levenshtein": "^1.0.12",
@@ -11654,6 +11626,12 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/webpack-cli/node_modules/colorette": {
+			"version": "2.0.16",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+			"integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+			"dev": true
 		},
 		"node_modules/webpack-cli/node_modules/commander": {
 			"version": "7.2.0",
@@ -11709,12 +11687,12 @@
 			}
 		},
 		"node_modules/webpack-dev-middleware": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.1.0.tgz",
-			"integrity": "sha512-oT660AR1gOnU/NTdUQi3EiGR0iXG7CFxmKsj3ylWCBA2khJ8LFHK+sKv3BZEsC11gl1eChsltRhzUq7nWj7XIQ==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.2.1.tgz",
+			"integrity": "sha512-Kx1X+36Rn9JaZcQMrJ7qN3PMAuKmEDD9ZISjUj3Cgq4A6PtwYsC4mpaKotSRYH3iOF6HsUa8viHKS59FlyVifQ==",
 			"dev": true,
 			"dependencies": {
-				"colorette": "^1.2.2",
+				"colorette": "^2.0.10",
 				"memfs": "^3.2.2",
 				"mime-types": "^2.1.31",
 				"range-parser": "^1.2.1",
@@ -11730,6 +11708,12 @@
 			"peerDependencies": {
 				"webpack": "^4.0.0 || ^5.0.0"
 			}
+		},
+		"node_modules/webpack-dev-middleware/node_modules/colorette": {
+			"version": "2.0.16",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+			"integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+			"dev": true
 		},
 		"node_modules/webpack-dev-middleware/node_modules/schema-utils": {
 			"version": "3.1.1",
@@ -11750,15 +11734,15 @@
 			}
 		},
 		"node_modules/webpack-dev-server": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.2.1.tgz",
-			"integrity": "sha512-SQrIyQDZsTaF84p/WMAXNRKxjTeIaewhDIiHYZ423ENhNAsQWyubvqPTn0IoLMGkbhWyWv8/GYnCjItt0ZNC5w==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.3.1.tgz",
+			"integrity": "sha512-qNXQCVYo1kYhH9pgLtm8LRNkXX3XzTfHSj/zqzaqYzGPca+Qjr+81wj1jgPMCHhIhso9WEQ+kX9z23iG9PzQ7w==",
 			"dev": true,
 			"dependencies": {
 				"ansi-html-community": "^0.0.8",
 				"bonjour": "^3.5.0",
 				"chokidar": "^3.5.1",
-				"colorette": "^1.2.2",
+				"colorette": "^2.0.10",
 				"compression": "^1.7.4",
 				"connect-history-api-fallback": "^1.6.0",
 				"del": "^6.0.0",
@@ -11778,7 +11762,7 @@
 				"spdy": "^4.0.2",
 				"strip-ansi": "^7.0.0",
 				"url": "^0.11.0",
-				"webpack-dev-middleware": "^5.1.0",
+				"webpack-dev-middleware": "^5.2.1",
 				"ws": "^8.1.0"
 			},
 			"bin": {
@@ -11808,10 +11792,16 @@
 				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
 			}
 		},
+		"node_modules/webpack-dev-server/node_modules/colorette": {
+			"version": "2.0.16",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+			"integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+			"dev": true
+		},
 		"node_modules/webpack-dev-server/node_modules/open": {
-			"version": "8.2.1",
-			"resolved": "https://registry.npmjs.org/open/-/open-8.2.1.tgz",
-			"integrity": "sha512-rXILpcQlkF/QuFez2BJDf3GsqpjGKbkUUToAIGo9A0Q6ZkoSGogZJulrUdwRkrAsoQvoZsrjCYt8+zblOk7JQQ==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-8.3.0.tgz",
+			"integrity": "sha512-7INcPWb1UcOwSQxAXTnBJ+FxVV4MPs/X++FWWBtgY69/J5lc+tCteMt/oFK1MnkyHC4VILLa9ntmwKTwDR4Q9w==",
 			"dev": true,
 			"dependencies": {
 				"define-lazy-prop": "^2.0.0",
@@ -11859,9 +11849,9 @@
 			}
 		},
 		"node_modules/webpack-dev-server/node_modules/ws": {
-			"version": "8.2.2",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.2.2.tgz",
-			"integrity": "sha512-Q6B6H2oc8QY3llc3cB8kVmQ6pnJWVQbP7Q5algTcIxx7YEpc0oU4NBVHlztA7Ekzfhw2r0rPducMUiCGWKQRzw==",
+			"version": "8.2.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+			"integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
 			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"
@@ -11914,9 +11904,9 @@
 			}
 		},
 		"node_modules/webpack/node_modules/acorn-import-assertions": {
-			"version": "1.7.6",
-			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.7.6.tgz",
-			"integrity": "sha512-FlVvVFA1TX6l3lp8VjDnYYq7R1nyW6x3svAt4nDgrWQ9SBaSh9CnbwgSUTasgfNfOG5HlM1ehugCvM+hjo56LA==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
 			"dev": true,
 			"peerDependencies": {
 				"acorn": "^8"
@@ -12258,9 +12248,9 @@
 	},
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-			"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
+			"integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
 			"devOptional": true,
 			"requires": {
 				"@babel/highlight": "^7.14.5"
@@ -12273,20 +12263,20 @@
 			"devOptional": true
 		},
 		"@babel/core": {
-			"version": "7.15.5",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.5.tgz",
-			"integrity": "sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.8.tgz",
+			"integrity": "sha512-3UG9dsxvYBMYwRv+gS41WKHno4K60/9GPy1CJaH6xy3Elq8CTtvtjT5R5jmNhXfCYLX2mTw+7/aq5ak/gOE0og==",
 			"devOptional": true,
 			"requires": {
-				"@babel/code-frame": "^7.14.5",
-				"@babel/generator": "^7.15.4",
+				"@babel/code-frame": "^7.15.8",
+				"@babel/generator": "^7.15.8",
 				"@babel/helper-compilation-targets": "^7.15.4",
-				"@babel/helper-module-transforms": "^7.15.4",
+				"@babel/helper-module-transforms": "^7.15.8",
 				"@babel/helpers": "^7.15.4",
-				"@babel/parser": "^7.15.5",
+				"@babel/parser": "^7.15.8",
 				"@babel/template": "^7.15.4",
 				"@babel/traverse": "^7.15.4",
-				"@babel/types": "^7.15.4",
+				"@babel/types": "^7.15.6",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -12296,12 +12286,12 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.15.4",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
-			"integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
+			"integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
 			"devOptional": true,
 			"requires": {
-				"@babel/types": "^7.15.4",
+				"@babel/types": "^7.15.6",
 				"jsesc": "^2.5.1",
 				"source-map": "^0.5.0"
 			}
@@ -12434,19 +12424,19 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.15.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.4.tgz",
-			"integrity": "sha512-9fHHSGE9zTC++KuXLZcB5FKgvlV83Ox+NLUmQTawovwlJ85+QMhk1CnVk406CQVj97LaWod6KVjl2Sfgw9Aktw==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.8.tgz",
+			"integrity": "sha512-DfAfA6PfpG8t4S6npwzLvTUpp0sS7JrcuaMiy1Y5645laRJIp/LiLGIBbQKaXSInK8tiGNI7FL7L8UvB8gdUZg==",
 			"devOptional": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.15.4",
 				"@babel/helper-replace-supers": "^7.15.4",
 				"@babel/helper-simple-access": "^7.15.4",
 				"@babel/helper-split-export-declaration": "^7.15.4",
-				"@babel/helper-validator-identifier": "^7.14.9",
+				"@babel/helper-validator-identifier": "^7.15.7",
 				"@babel/template": "^7.15.4",
 				"@babel/traverse": "^7.15.4",
-				"@babel/types": "^7.15.4"
+				"@babel/types": "^7.15.6"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
@@ -12515,9 +12505,9 @@
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.14.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-			"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+			"version": "7.15.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+			"integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
 			"devOptional": true
 		},
 		"@babel/helper-validator-option": {
@@ -12561,9 +12551,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.15.6",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.6.tgz",
-			"integrity": "sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
+			"integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==",
 			"devOptional": true
 		},
 		"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
@@ -12578,9 +12568,9 @@
 			}
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.15.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.15.4.tgz",
-			"integrity": "sha512-2zt2g5vTXpMC3OmK6uyjvdXptbhBXfA77XGrd3gh93zwG8lZYBLOBImiGBEG0RANu3JqKEACCz5CGk73OJROBw==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.15.8.tgz",
+			"integrity": "sha512-2Z5F2R2ibINTc63mY7FLqGfEbmofrHU9FitJW1Q7aPaKFhiPvSq6QEt/BoWN5oME3GVyjcRuNNSRbb9LC0CSWA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.14.5",
@@ -12610,9 +12600,9 @@
 			}
 		},
 		"@babel/plugin-proposal-decorators": {
-			"version": "7.15.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.15.4.tgz",
-			"integrity": "sha512-WNER+YLs7avvRukEddhu5PSfSaMMimX2xBFgLQS7Bw16yrUxJGWidO9nQp+yLy9MVybg5Ba3BlhAw+BkdhpDmg==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.15.8.tgz",
+			"integrity": "sha512-5n8+xGK7YDrXF+WAORg3P7LlCCdiaAyKLZi22eP2BwTy4kJ0kFUMMDCj4nQ8YrKyNZgjhU/9eRVqONnjB3us8g==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-create-class-features-plugin": "^7.15.4",
@@ -13179,15 +13169,15 @@
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.15.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.15.0.tgz",
-			"integrity": "sha512-sfHYkLGjhzWTq6xsuQ01oEsUYjkHRux9fW1iUA68dC7Qd8BS1Unq4aZ8itmQp95zUzIcyR2EbNMTzAicFj+guw==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.15.8.tgz",
+			"integrity": "sha512-+6zsde91jMzzvkzuEA3k63zCw+tm/GvuuabkpisgbDMTPQsIMHllE3XczJFFtEHLjjhKQFZmGQVRdELetlWpVw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.14.5",
+				"@babel/helper-module-imports": "^7.15.4",
 				"@babel/helper-plugin-utils": "^7.14.5",
 				"babel-plugin-polyfill-corejs2": "^0.2.2",
-				"babel-plugin-polyfill-corejs3": "^0.2.2",
+				"babel-plugin-polyfill-corejs3": "^0.2.5",
 				"babel-plugin-polyfill-regenerator": "^0.2.2",
 				"semver": "^6.3.0"
 			}
@@ -13202,13 +13192,13 @@
 			}
 		},
 		"@babel/plugin-transform-spread": {
-			"version": "7.14.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.14.6.tgz",
-			"integrity": "sha512-Zr0x0YroFJku7n7+/HH3A2eIrGMjbmAIbJSVv0IZ+t3U2WUQUA64S/oeied2e+MaGSjmt4alzBCsK9E8gh+fag==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.15.8.tgz",
+			"integrity": "sha512-/daZ8s2tNaRekl9YJa9X4bzjpeRZLt122cpgFnQPLGUe61PH8zMEBmYqKkW5xF5JUEh5buEGXJoQpqBmIbpmEQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.14.5",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.14.5"
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.15.4"
 			}
 		},
 		"@babel/plugin-transform-sticky-regex": {
@@ -13258,9 +13248,9 @@
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.15.6",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.15.6.tgz",
-			"integrity": "sha512-L+6jcGn7EWu7zqaO2uoTDjjMBW+88FXzV8KvrBl2z6MtRNxlsmUNRlZPaNNPUTgqhyC5DHNFk/2Jmra+ublZWw==",
+			"version": "7.15.8",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.15.8.tgz",
+			"integrity": "sha512-rCC0wH8husJgY4FPbHsiYyiLxSY8oMDJH7Rl6RQMknbN9oDDHhM9RDFvnGM2MgkbUJzSQB4gtuwygY5mCqGSsA==",
 			"dev": true,
 			"requires": {
 				"@babel/compat-data": "^7.15.0",
@@ -13268,7 +13258,7 @@
 				"@babel/helper-plugin-utils": "^7.14.5",
 				"@babel/helper-validator-option": "^7.14.5",
 				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.15.4",
-				"@babel/plugin-proposal-async-generator-functions": "^7.15.4",
+				"@babel/plugin-proposal-async-generator-functions": "^7.15.8",
 				"@babel/plugin-proposal-class-properties": "^7.14.5",
 				"@babel/plugin-proposal-class-static-block": "^7.15.4",
 				"@babel/plugin-proposal-dynamic-import": "^7.14.5",
@@ -13323,7 +13313,7 @@
 				"@babel/plugin-transform-regenerator": "^7.14.5",
 				"@babel/plugin-transform-reserved-words": "^7.14.5",
 				"@babel/plugin-transform-shorthand-properties": "^7.14.5",
-				"@babel/plugin-transform-spread": "^7.14.6",
+				"@babel/plugin-transform-spread": "^7.15.8",
 				"@babel/plugin-transform-sticky-regex": "^7.14.5",
 				"@babel/plugin-transform-template-literals": "^7.14.5",
 				"@babel/plugin-transform-typeof-symbol": "^7.14.5",
@@ -13332,7 +13322,7 @@
 				"@babel/preset-modules": "^0.1.4",
 				"@babel/types": "^7.15.6",
 				"babel-plugin-polyfill-corejs2": "^0.2.2",
-				"babel-plugin-polyfill-corejs3": "^0.2.2",
+				"babel-plugin-polyfill-corejs3": "^0.2.5",
 				"babel-plugin-polyfill-regenerator": "^0.2.2",
 				"core-js-compat": "^3.16.0",
 				"semver": "^6.3.0"
@@ -13611,9 +13601,9 @@
 			}
 		},
 		"@polka/url": {
-			"version": "1.0.0-next.20",
-			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.20.tgz",
-			"integrity": "sha512-88p7+M0QGxKpmnkfXjS4V26AnoC/eiqZutE8GLdaI5X12NY75bXSdTY9NkmYb2Xyk1O+MmkuO6Frmsj84V6I8Q==",
+			"version": "1.0.0-next.21",
+			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
+			"integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
 			"dev": true
 		},
 		"@prefresh/babel-plugin": {
@@ -13652,57 +13642,57 @@
 			"dev": true
 		},
 		"@searchspring/snap-client": {
-			"version": "0.9.3",
-			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-client/0.9.3/2531707a05b8d276de323cf52669bd2d052d29010774adf3d764e350aab1f400",
-			"integrity": "sha512-p6WAcWRW7SkIzk5AO6Kz4TgX5cDVcOu88WqJAx4ZMH4xaR/lgJQtNWnuNOrZAfGs3edAMyL7CU04CpOx6yeuOA==",
+			"version": "0.9.7",
+			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-client/0.9.7/75d6356f32fa7ccbfd299924678206a44d4c0cb6323795c70fbd02fa459b35cd",
+			"integrity": "sha512-FzuomJrX5brBwRwMDeandhqwGhIAMI7sJNWuxn7AY+KBnvnqQ3yhkw2gHFROWIAXufET+LXRo24I3HQesGR+/w==",
 			"requires": {
 				"whatwg-fetch": "^3.6.2"
 			}
 		},
 		"@searchspring/snap-controller": {
-			"version": "0.9.3",
-			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-controller/0.9.3/7a0c797a8e35f3330f276ad0f3222550c3027eb685874882ad09573dbf8013d9",
-			"integrity": "sha512-Eve5QQ5kOynHHi6I1EX45HOcBgTzOagGT9PIX+C4EnDnF9NJqQJLIMQnwwOnJdqjaIB+45gPBg4B35g1z9wGLQ==",
+			"version": "0.9.7",
+			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-controller/0.9.7/234fec67a22d55740be37a2cbffc395ed274bb1d16d244cca7135889570f54c1",
+			"integrity": "sha512-dW9wJmhKdBHJTq4YO+oEnE8p+yTIo9P2Lhk/NBXnnodO6Q3OcYnzx4aNJLK8JNWEcqAyQn2l4VIGocgreRaBzQ==",
 			"requires": {
-				"@searchspring/snap-toolbox": "^0.9.3",
+				"@searchspring/snap-toolbox": "^0.9.7",
 				"deepmerge": "^4.2.2"
 			}
 		},
 		"@searchspring/snap-event-manager": {
-			"version": "0.9.3",
-			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-event-manager/0.9.3/f701e0a43866a572a29f9554b19bbfb07855d4214a78c33f63e5e71e2fc9b37d",
-			"integrity": "sha512-Btaicl7VACIXYXLm38RODwhO6fDlHObSqmwz/uxvKo91oFaE+IP8WXJkJWLXjyC++qSQEje6bZ+E7GS3Jj5Qlg=="
+			"version": "0.9.7",
+			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-event-manager/0.9.7/96edff2ace9df15948a6d4dcab79225e963636e6dc6d4f0c13ffd7fac0034361",
+			"integrity": "sha512-+5bCJRDhkvMmaYtAybcfvSEx5xnF/3C2IDJksOfDGHzOVM0Hr2qulVVHdg6dhxqfm3FzximTi7TtkkO6iltr3A=="
 		},
 		"@searchspring/snap-logger": {
-			"version": "0.9.3",
-			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-logger/0.9.3/7add1619a863299324cb4b5bd1960aeded85d654bd36ee5ea4ac4d5f52ecf8fc",
-			"integrity": "sha512-G0t+WIBDhrn5Iv3u/r3rAEQQxi6TbUYBNOkayEC2cYZcpVcZwKe2SsQ+RBbdQFLkZfynFdwqxwiAS7bR2BkUaw=="
+			"version": "0.9.7",
+			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-logger/0.9.7/87316d32ea2b8b9c2b9c441bb16d21b49bfe372e013a4cd44c3f35b4b18a0e84",
+			"integrity": "sha512-9rpBcHq8tz1kIaXaKY9bn9kvzmpmS5iwWP+uANPm13k6UldKDXRA6BhAGkEimLIX7fX7TRSZKasvBxKjkryBVw=="
 		},
 		"@searchspring/snap-preact": {
-			"version": "0.9.3",
-			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-preact/0.9.3/f07075a8da82cb661c271e378e140ffd967cdfefa1b2188cc745cde5a6952b59",
-			"integrity": "sha512-3WuY6DPz93z31A5cF9qW76Tb4A1DP7ZHFQp6QBmMzJoRUe3pi6H4s8WhLjep9fUeayIgxzrQEEOYeyqly8guWw==",
+			"version": "0.9.7",
+			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-preact/0.9.7/d40c58ca382b97d6f503cabe511a6b907719f949d5482ba5cc92f731ebb1bb99",
+			"integrity": "sha512-ka/K8bgyeyMErcet7BnZeV+ml0bXFsbpl3mkVW0kMKU0oQ8UKIUAg5C6BsgwYktepVNUNc7uSKwUf71G4YIKdQ==",
 			"requires": {
-				"@searchspring/snap-client": "^0.9.3",
-				"@searchspring/snap-controller": "^0.9.3",
-				"@searchspring/snap-event-manager": "^0.9.3",
-				"@searchspring/snap-logger": "^0.9.3",
-				"@searchspring/snap-profiler": "^0.9.3",
-				"@searchspring/snap-store-mobx": "^0.9.3",
-				"@searchspring/snap-toolbox": "^0.9.3",
-				"@searchspring/snap-tracker": "^0.9.3",
-				"@searchspring/snap-url-manager": "^0.9.3",
+				"@searchspring/snap-client": "^0.9.7",
+				"@searchspring/snap-controller": "^0.9.7",
+				"@searchspring/snap-event-manager": "^0.9.7",
+				"@searchspring/snap-logger": "^0.9.7",
+				"@searchspring/snap-profiler": "^0.9.7",
+				"@searchspring/snap-store-mobx": "^0.9.7",
+				"@searchspring/snap-toolbox": "^0.9.7",
+				"@searchspring/snap-tracker": "^0.9.7",
+				"@searchspring/snap-url-manager": "^0.9.7",
 				"deepmerge": "^4.2.2"
 			}
 		},
 		"@searchspring/snap-preact-components": {
-			"version": "0.9.3",
-			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-preact-components/0.9.3/bfc1de0421db8bc32699f8243f6e9c3ec7d5a99f3ca9e65166ce58523dae0fda",
-			"integrity": "sha512-0BkNI5MltbKJUjjPjK6fvUXcEVIVfEgGLVmpBF19hJP708m1ttxD078H6pp2it3LGSngfssSqZ4nOJef+KwHmw==",
+			"version": "0.9.7",
+			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-preact-components/0.9.7/396f9f366552a0a328b25ae0756699b656f151912ffdf112a4f4f506c3627108",
+			"integrity": "sha512-MMCRN7g17uHRJI+XE182nqKbQAAss1O+D0vqJaszBdB8W847kwtYWYubZMNl5bIGKH2411XtXCNhct3jCN1umw==",
 			"requires": {
 				"@emotion/react": "^11.4.1",
-				"@searchspring/snap-preact": "^0.9.3",
-				"@searchspring/snap-toolbox": "^0.9.3",
+				"@searchspring/snap-preact": "^0.9.7",
+				"@searchspring/snap-toolbox": "^0.9.7",
 				"classnames": "^2.3.1",
 				"mobx-react-lite": "^3.2.1",
 				"react-ranger": "^2.1.0",
@@ -13710,39 +13700,39 @@
 			}
 		},
 		"@searchspring/snap-profiler": {
-			"version": "0.9.3",
-			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-profiler/0.9.3/5881584ace62f9824927721a99cb8c2a1c8e1d8ddd799ead41925ea6b061f75c",
-			"integrity": "sha512-YvSf9wbl8KjGJwqgjoFUs+uIAVR+Vx3/Etxqfha+Qa07W4zgYRs4zo+7aboJ1pqD2SB6FeAZTRnGLk1xeV7G9A=="
+			"version": "0.9.7",
+			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-profiler/0.9.7/0e889ab1512afcfa4767231c6fe7b096ce8830d6be715a290e479d29a462ea99",
+			"integrity": "sha512-h4luxEKPMkpROHtgOIL1dZnbecpo2X82dAlgkLwobOzR7pZbYWiBXju041vEUCdVHU+ZW3OzKxN5FrMDII4iYw=="
 		},
 		"@searchspring/snap-store-mobx": {
-			"version": "0.9.3",
-			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-store-mobx/0.9.3/b87caccfca9b974787d1ecbe9d230f767bd0906dbade8909694a79b932ea5b10",
-			"integrity": "sha512-tzkAcb/EXuuF0P4on/wYjBsWy7GmXpKGZfNBtOrgXo9YYHwfswmQ9wYoUPCLwwbqas95/Ffc7KUMti937HvhyQ==",
+			"version": "0.9.7",
+			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-store-mobx/0.9.7/3f4e2e42df7624b5a169c104b098f24e2b35feb6ed702cc307aef527c12a2135",
+			"integrity": "sha512-DV2uV1A61pn0WUz36Krbc2hd07qrWAMoUSkYjO7vEWE+M49NSMQmLKzHSxZhLN0+hjl218k66fVPOPIyCvTPtQ==",
 			"requires": {
-				"@searchspring/snap-toolbox": "^0.9.3",
+				"@searchspring/snap-toolbox": "^0.9.7",
 				"mobx": "^6.3.3"
 			}
 		},
 		"@searchspring/snap-toolbox": {
-			"version": "0.9.3",
-			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-toolbox/0.9.3/905e73c99eacc58be6fbf5fc9aec3b488a07d5a568358a57ed402d7b12c78008",
-			"integrity": "sha512-JRmEzfx3G84wY3XGED73OHs6qTy++LpISwkBkikwOy4TPOYCQJfVIMCqPcC8yVk/UHrCZXnB37S+aABWrVYzBA=="
+			"version": "0.9.7",
+			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-toolbox/0.9.7/0b16436780458119e9adc5e88c0d9b1557a3dc42427547d87e310fc9ba7c57e5",
+			"integrity": "sha512-B4twCHphmwynSAKkYekDlOBVkCO2nhCMixdyVSWWbIbRwkabjn6nuyAwNKblL7tSD8e7MoaqAOJZ3toPGzLcjA=="
 		},
 		"@searchspring/snap-tracker": {
-			"version": "0.9.3",
-			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-tracker/0.9.3/d7114c9e78ac563fe8ca6ec88bf51af536c4b3347b5a7fa3285e5c70b2a079fd",
-			"integrity": "sha512-tMvnhh0b1ocI1ud7oUM5OZRMNlwiRMnM/nytXzMi5NcVCoytq19f8oeQia9mUXKv8MG3FFSKrRnxTfdf9NPJOQ==",
+			"version": "0.9.7",
+			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-tracker/0.9.7/b53c5005d38b344ba45183e8a43961ebde013265ff3c41e9ab5892aaa4b17b72",
+			"integrity": "sha512-WWPvlZQE6JquXvnR7KD3vdJ+Mj32z+p2vbNEDlhAvKZ8C22KMvyaKgBYjZ3upxQmhgns0MJ69eZl6vnjQr5Sww==",
 			"requires": {
-				"@searchspring/snap-store-mobx": "^0.9.3",
-				"@searchspring/snap-toolbox": "^0.9.3",
+				"@searchspring/snap-store-mobx": "^0.9.7",
+				"@searchspring/snap-toolbox": "^0.9.7",
 				"deepmerge": "^4.2.2",
 				"uuid": "^8.3.2"
 			}
 		},
 		"@searchspring/snap-url-manager": {
-			"version": "0.9.3",
-			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-url-manager/0.9.3/9c2237d2904db34dc18d640dbdededf13f866dd30261125669e756c68b2d4241",
-			"integrity": "sha512-c2bLNS0G/aNYD9NFGWsll0263L+cQYFozqgGQHSTIffo4Fg4ow5GIa3Cjw8QFyWZMxmEFWF8BDR7Q1qXKg1KVw==",
+			"version": "0.9.7",
+			"resolved": "https://npm.pkg.github.com/download/@searchspring/snap-url-manager/0.9.7/d3069debc58ee1934c3afbeb08183dca4ecc92533e4c4979aaf557b7c3f04967",
+			"integrity": "sha512-lscXuQGqURPW2NlbQYkHKHakvxRq9ir3nfuu6117ZeLUAw6t/7iwfcOF0jwywK3rxNMoe9UgNYoMoLUWWO/3ag==",
 			"requires": {
 				"deepmerge": "^4.2.2",
 				"seamless-immutable": "^7.1.4"
@@ -13764,9 +13754,9 @@
 			}
 		},
 		"@types/eslint": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.0.tgz",
-			"integrity": "sha512-07XlgzX0YJUn4iG1ocY4IX9DzKSmMGUs6ESKlxWhZRaa0fatIWaHWUVapcuGa8r5HFnTqzj+4OCjd5f7EZ/i/A==",
+			"version": "7.28.1",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.1.tgz",
+			"integrity": "sha512-XhZKznR3i/W5dXqUhgU9fFdJekufbeBd5DALmkuXoeFcjbQcPk+2cL+WLHf6Q81HWAnM2vrslIHpGVyCAviRwg==",
 			"dev": true,
 			"requires": {
 				"@types/estree": "*",
@@ -13811,9 +13801,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.17.17",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.17.tgz",
-			"integrity": "sha512-niAjcewgEYvSPCZm3OaM9y6YQrL2SEPH9PymtE6fuZAvFiP6ereCcvApGl2jKTq7copTIguX3PBvfP08LN4LvQ==",
+			"version": "14.17.22",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.22.tgz",
+			"integrity": "sha512-6Mgu9YWd8j0dk9M8V9+5w6ktqIFCcn/fFXAVIDFk/niAOFiOiz4GeFAMWYAQjKrcsASbFqMkqR8/Y2wuVCAkNg==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -13835,9 +13825,9 @@
 			"dev": true
 		},
 		"@types/sinonjs__fake-timers": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.3.tgz",
-			"integrity": "sha512-E1dU4fzC9wN2QK2Cr1MLCfyHM8BoNnRFvuf45LYMPNDA+WqbNzC45S4UzPxvp1fFJ1rvSGU0bPvdd35VLmXG8g==",
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.4.tgz",
+			"integrity": "sha512-IFQTJARgMUBF+xVd2b+hIgXWrZEjND3vJtRCvIelcFB5SIXfjV4bOHbHJ0eXKh+0COrBRc8MqteKAz/j88rE0A==",
 			"dev": true
 		},
 		"@types/sizzle": {
@@ -14003,25 +13993,25 @@
 			}
 		},
 		"@webpack-cli/configtest": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.4.tgz",
-			"integrity": "sha512-cs3XLy+UcxiP6bj0A6u7MLLuwdXJ1c3Dtc0RkKg+wiI1g/Ti1om8+/2hc2A2B60NbBNAbMgyBMHvyymWm/j4wQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
+			"integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
 			"dev": true,
 			"requires": {}
 		},
 		"@webpack-cli/info": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.3.0.tgz",
-			"integrity": "sha512-ASiVB3t9LOKHs5DyVUcxpraBXDOKubYu/ihHhU+t1UPpxsivg6Od2E2qU4gJCekfEddzRBzHhzA/Acyw/mlK/w==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
+			"integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
 			"dev": true,
 			"requires": {
 				"envinfo": "^7.7.3"
 			}
 		},
 		"@webpack-cli/serve": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.5.2.tgz",
-			"integrity": "sha512-vgJ5OLWadI8aKjDlOH3rb+dYyPd2GTZuQC/Tihjct6F9GpXGZINo3Y/IVuZVTM1eDQB+/AOsjPUWH/WySDaXvw==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
+			"integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
 			"dev": true,
 			"requires": {}
 		},
@@ -14108,52 +14098,12 @@
 			"dev": true
 		},
 		"ansi-align": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
-			"integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+			"integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
 			"dev": true,
 			"requires": {
-				"string-width": "^3.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"emoji-regex": {
-					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				}
+				"string-width": "^4.1.0"
 			}
 		},
 		"ansi-colors": {
@@ -14240,16 +14190,16 @@
 			"dev": true
 		},
 		"array-includes": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
-			"integrity": "sha512-gcem1KlBU7c9rB+Rq8/3PPKsK2kjqeEBa3bD5kkQo4nYlOHQCJqIJFqBXDEfwaRuYTT4E+FxA9xez7Gf/e3Q7A==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
+			"integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.0-next.2",
+				"es-abstract": "^1.19.1",
 				"get-intrinsic": "^1.1.1",
-				"is-string": "^1.0.5"
+				"is-string": "^1.0.7"
 			}
 		},
 		"array-union": {
@@ -14259,15 +14209,14 @@
 			"dev": true
 		},
 		"array.prototype.flatmap": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.4.tgz",
-			"integrity": "sha512-r9Z0zYoxqHz60vvQbWEdXIEtCwHF0yxaWfno9qzXeNHvfyl3BZqygmGzb84dsubyaXLH4husF+NFgMSdpZhk2Q==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.5.tgz",
+			"integrity": "sha512-08u6rVyi1Lj7oqWbS9nUxliETrtIROT4XGTA4D/LWGten6E3ocm7cy9SIrmNHOL5XVbVuckUp3X6Xyg8/zpvHA==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.0-next.1",
-				"function-bind": "^1.1.1"
+				"es-abstract": "^1.19.0"
 			}
 		},
 		"arrify": {
@@ -14386,13 +14335,13 @@
 			}
 		},
 		"babel-plugin-polyfill-corejs3": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.4.tgz",
-			"integrity": "sha512-z3HnJE5TY/j4EFEa/qpQMSbcUJZ5JQi+3UFjXzn6pQCmIKc5Ug5j98SuYyH+m4xQnvKlMDIW4plLfgyVnd0IcQ==",
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.5.tgz",
+			"integrity": "sha512-ninF5MQNwAX9Z7c9ED+H2pGt1mXdP4TqzlHKyPIYmJIYz0N+++uwdM7RnJukklhzJ54Q84vA4ZJkgs7lu5vqcw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-define-polyfill-provider": "^0.2.2",
-				"core-js-compat": "^3.14.0"
+				"core-js-compat": "^3.16.2"
 			}
 		},
 		"babel-plugin-polyfill-regenerator": {
@@ -14603,16 +14552,16 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.17.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.0.tgz",
-			"integrity": "sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==",
+			"version": "4.17.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.3.tgz",
+			"integrity": "sha512-59IqHJV5VGdcJZ+GZ2hU5n4Kv3YiASzW6Xk5g9tf5a/MAzGeFwgGWU39fVzNIOVcgB3+Gp+kiQu0HEfTVU/3VQ==",
 			"devOptional": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001254",
-				"colorette": "^1.3.0",
-				"electron-to-chromium": "^1.3.830",
+				"caniuse-lite": "^1.0.30001264",
+				"electron-to-chromium": "^1.3.857",
 				"escalade": "^3.1.1",
-				"node-releases": "^1.1.75"
+				"node-releases": "^1.1.77",
+				"picocolors": "^0.2.1"
 			}
 		},
 		"buffer-crc32": {
@@ -14702,9 +14651,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001258",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001258.tgz",
-			"integrity": "sha512-RBByOG6xWXUp0CR2/WU2amXz3stjKpSl5J1xU49F1n2OxD//uBZO4wCKUiG+QMGf7CHGfDDcqoKriomoGVxTeA==",
+			"version": "1.0.30001265",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz",
+			"integrity": "sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw==",
 			"devOptional": true
 		},
 		"caseless": {
@@ -14759,9 +14708,9 @@
 			"dev": true
 		},
 		"chrome-launcher": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.14.0.tgz",
-			"integrity": "sha512-W//HpflaW6qBGrmuskup7g+XJZN6w03ko9QSIe5CtcTal2u0up5SeReK3Ll1Why4Ey8dPkv8XSodZyHPnGbVHQ==",
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.14.1.tgz",
+			"integrity": "sha512-iQ4s61NkIyaozsE2VKg1Vu3YGdD3JGw+fBBrt3FYJi7uflO9TvlTLW4MUq0fq3EKGhzB/QHPd5AsLb14+9++JQ==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
@@ -14893,7 +14842,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
 			"integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
-			"devOptional": true
+			"dev": true
 		},
 		"colors": {
 			"version": "1.4.0",
@@ -15039,18 +14988,18 @@
 			"dev": true
 		},
 		"core-js": {
-			"version": "3.17.3",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.17.3.tgz",
-			"integrity": "sha512-lyvajs+wd8N1hXfzob1LdOCCHFU4bGMbqqmLn1Q4QlCpDqWPpGf+p0nj+LNrvDDG33j0hZXw2nsvvVpHysxyNw==",
+			"version": "3.18.2",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.18.2.tgz",
+			"integrity": "sha512-zNhPOUoSgoizoSQFdX1MeZO16ORRb9FFQLts8gSYbZU5FcgXhp24iMWMxnOQo5uIaIG7/6FA/IqJPwev1o9ZXQ==",
 			"dev": true
 		},
 		"core-js-compat": {
-			"version": "3.17.3",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.17.3.tgz",
-			"integrity": "sha512-+in61CKYs4hQERiADCJsdgewpdl/X0GhEX77pjKgbeibXviIt2oxEjTc8O2fqHX8mDdBrDvX8MYD/RYsBv4OiA==",
+			"version": "3.18.2",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.18.2.tgz",
+			"integrity": "sha512-25VJYCJtGjZwLguj7d66oiHfmnVw3TMOZ0zV8DyMJp/aeQ3OjR519iOOeck08HMyVVRAqXxafc2Hl+5QstJrsQ==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.17.0",
+				"browserslist": "^4.17.3",
 				"semver": "7.0.0"
 			},
 			"dependencies": {
@@ -15111,9 +15060,9 @@
 			"dev": true
 		},
 		"css-loader": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.2.0.tgz",
-			"integrity": "sha512-/rvHfYRjIpymZblf49w8jYcRo2y9gj6rV8UroHGmBxKrIyGLokpycyKzp9OkitvqT29ZSpzJ0Ic7SpnJX3sC8g==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.4.0.tgz",
+			"integrity": "sha512-Dlt6qfsxI/w1vU0r8qDd4BtMPxWqJeY5qQU7SmmZfvbpe6Xl18McO4GhyaMLns24Y2VNPiZwJPQ8JSbg4qvQLw==",
 			"dev": true,
 			"requires": {
 				"icss-utils": "^5.1.0",
@@ -15164,9 +15113,9 @@
 			"integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw=="
 		},
 		"cypress": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/cypress/-/cypress-8.4.0.tgz",
-			"integrity": "sha512-RtVgGFR06ikyMaq/VqapeqOjGaIA42PpK7F0qe1MCiFArfUuJECsLmeYaOA+1TlmNUgJNMSF5fWKkZIJr5Uc7w==",
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/cypress/-/cypress-8.6.0.tgz",
+			"integrity": "sha512-F7qEK/6Go5FsqTueR+0wEw2vOVKNgk5847Mys8vsWkzPoEKdxs+7N9Y1dit+zhaZCLtMPyrMwjfA53ZFy+lSww==",
 			"dev": true,
 			"requires": {
 				"@cypress/request": "^2.88.6",
@@ -15203,6 +15152,7 @@
 				"minimist": "^1.2.5",
 				"ospath": "^1.2.2",
 				"pretty-bytes": "^5.6.0",
+				"proxy-from-env": "1.0.0",
 				"ramda": "~0.27.1",
 				"request-progress": "^3.0.0",
 				"supports-color": "^8.1.1",
@@ -15558,9 +15508,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.842",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.842.tgz",
-			"integrity": "sha512-P/nDMPIYdb2PyqCQwhTXNi5JFjX1AsDVR0y6FrHw752izJIAJ+Pn5lugqyBq4tXeRSZBMBb2ZGvRGB1djtELEQ==",
+			"version": "1.3.866",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.866.tgz",
+			"integrity": "sha512-iYze6TpDXWxk+sfcpUUdTs6Pv/3kG45Pnjer2DxEeFw0N08bZeNLuz97s2lMgy8yObon48o0WHY2Bkg3xuAPOA==",
 			"devOptional": true
 		},
 		"emoji-regex": {
@@ -15591,9 +15541,9 @@
 			}
 		},
 		"enhanced-resolve": {
-			"version": "5.8.2",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz",
-			"integrity": "sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==",
+			"version": "5.8.3",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
+			"integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.2.4",
@@ -15631,9 +15581,9 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.18.6",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
-			"integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+			"integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
@@ -15647,7 +15597,9 @@
 				"is-callable": "^1.2.4",
 				"is-negative-zero": "^2.0.1",
 				"is-regex": "^1.1.4",
+				"is-shared-array-buffer": "^1.0.1",
 				"is-string": "^1.0.7",
+				"is-weakref": "^1.0.1",
 				"object-inspect": "^1.11.0",
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.2",
@@ -15657,9 +15609,9 @@
 			}
 		},
 		"es-module-lexer": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.7.1.tgz",
-			"integrity": "sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw==",
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
 			"dev": true
 		},
 		"es-to-primitive": {
@@ -15842,23 +15794,24 @@
 			}
 		},
 		"eslint-plugin-react": {
-			"version": "7.25.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.25.2.tgz",
-			"integrity": "sha512-elx4585wgmryanJK4C5IoSKQyVZ+e7H0t2JOOtJNBql0cuercvSShvRReuLBbfx8687yW5yv+UL7pXwMsd6adQ==",
+			"version": "7.26.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz",
+			"integrity": "sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==",
 			"dev": true,
 			"requires": {
 				"array-includes": "^3.1.3",
 				"array.prototype.flatmap": "^1.2.4",
 				"doctrine": "^2.1.0",
 				"estraverse": "^5.2.0",
-				"has": "^1.0.3",
 				"jsx-ast-utils": "^2.4.1 || ^3.0.0",
 				"minimatch": "^3.0.4",
 				"object.entries": "^1.1.4",
 				"object.fromentries": "^2.0.4",
+				"object.hasown": "^1.0.0",
 				"object.values": "^1.1.4",
 				"prop-types": "^15.7.2",
 				"resolve": "^2.0.0-next.3",
+				"semver": "^6.3.0",
 				"string.prototype.matchall": "^4.0.5"
 			},
 			"dependencies": {
@@ -15970,9 +15923,9 @@
 			"dev": true
 		},
 		"eventemitter2": {
-			"version": "6.4.4",
-			"resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.4.tgz",
-			"integrity": "sha512-HLU3NDY6wARrLCEwyGKRBvuWYyvW6mHYv72SJJAH3iJN3a6eVUvkjFkcxah1bcTgGVBBrFdIopBJPhCQFMLyXw==",
+			"version": "6.4.5",
+			"resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.5.tgz",
+			"integrity": "sha512-bXE7Dyc1i6oQElDG0jMRZJrRAn9QR2xyyFGmBdZleNmyQX0FqGYmhZIrIrpPfm/w//LTo4tVQGOGQcGCb5q9uw==",
 			"dev": true
 		},
 		"eventemitter3": {
@@ -16526,9 +16479,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.7",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-			"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
@@ -16600,6 +16553,22 @@
 				"glob": "~7.1.1",
 				"lodash": "~4.17.10",
 				"minimatch": "~3.0.2"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.7",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+					"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				}
 			}
 		},
 		"got": {
@@ -16920,9 +16889,9 @@
 			"dev": true
 		},
 		"import-local": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
-			"integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.3.tgz",
+			"integrity": "sha512-bE9iaUY3CXH8Cwfan/abDKAxe1KGT9kyGsBPqf6DMK/z0a2OzAsrukeYNgIH6cH5Xr452jb1TUL8rSfCLjZ9uA==",
 			"dev": true,
 			"requires": {
 				"pkg-dir": "^4.2.0",
@@ -17099,9 +17068,9 @@
 			}
 		},
 		"is-core-module": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
-			"integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.7.0.tgz",
+			"integrity": "sha512-ByY+tjCciCr+9nLryBYcSD50EOGWt95c7tIsKTG1J2ixKKXPvF7Ej3AVd+UfDydAJom3biBGDBALaO79ktwgEQ==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -17135,9 +17104,9 @@
 			"dev": true
 		},
 		"is-glob": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
 			"dev": true,
 			"requires": {
 				"is-extglob": "^2.1.1"
@@ -17238,6 +17207,12 @@
 			"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
 			"dev": true
 		},
+		"is-shared-array-buffer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+			"integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+			"dev": true
+		},
 		"is-stream": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -17273,6 +17248,15 @@
 			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
 			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
 			"dev": true
+		},
+		"is-weakref": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
+			"integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.0"
+			}
 		},
 		"is-wsl": {
 			"version": "2.2.0",
@@ -17314,9 +17298,9 @@
 			"dev": true
 		},
 		"jest-worker": {
-			"version": "27.2.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.2.0.tgz",
-			"integrity": "sha512-laB0ZVIBz+voh/QQy9dmUuuDsadixeerrKqyVpgPz+CCWiOYjOBabUXHIXZhsdvkWbLqSHbgkAHWl5cg24Q6RA==",
+			"version": "27.2.5",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.2.5.tgz",
+			"integrity": "sha512-HTjEPZtcNKZ4LnhSp02NEH4vE+5OpJ0EsOWYvGQpHgUMLngydESAAMH5Wd/asPf29+XUDQZszxpLg1BkIIA2aw==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
@@ -17516,9 +17500,9 @@
 			}
 		},
 		"lighthouse": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-8.4.0.tgz",
-			"integrity": "sha512-O4DE/UFvn63iu1hRNFRYY+ZzEHfN463fBSxUuux4cFXRd5c398FgL6VDiZgmy28jQ9U6lYmsKZW1xLcWLEuO+g==",
+			"version": "8.5.1",
+			"resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-8.5.1.tgz",
+			"integrity": "sha512-phe3g77N5AE5pf5TARUBb9uHLvvzwpd2z/S0G+6KrC5ShEe2laSxkiiTLo/jYxsrmy5kL7qohVztdOuafy4HGQ==",
 			"dev": true,
 			"requires": {
 				"axe-core": "4.2.3",
@@ -17601,65 +17585,31 @@
 			"dev": true
 		},
 		"lint-staged": {
-			"version": "11.1.2",
-			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-11.1.2.tgz",
-			"integrity": "sha512-6lYpNoA9wGqkL6Hew/4n1H6lRqF3qCsujVT0Oq5Z4hiSAM7S6NksPJ3gnr7A7R52xCtiZMcEUNNQ6d6X5Bvh9w==",
+			"version": "11.2.3",
+			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-11.2.3.tgz",
+			"integrity": "sha512-Tfmhk8O2XFMD25EswHPv+OYhUjsijy5D7liTdxeXvhG2rsadmOLFtyj8lmlfoFFXY8oXWAIOKpoI+lJe1DB1mw==",
 			"dev": true,
 			"requires": {
-				"chalk": "^4.1.1",
-				"cli-truncate": "^2.1.0",
-				"commander": "^7.2.0",
-				"cosmiconfig": "^7.0.0",
-				"debug": "^4.3.1",
+				"cli-truncate": "2.1.0",
+				"colorette": "^1.4.0",
+				"commander": "^8.2.0",
+				"cosmiconfig": "^7.0.1",
+				"debug": "^4.3.2",
 				"enquirer": "^2.3.6",
-				"execa": "^5.0.0",
-				"listr2": "^3.8.2",
-				"log-symbols": "^4.1.0",
+				"execa": "^5.1.1",
+				"listr2": "^3.12.2",
 				"micromatch": "^4.0.4",
 				"normalize-path": "^3.0.0",
 				"please-upgrade-node": "^3.2.0",
 				"string-argv": "0.3.1",
-				"stringify-object": "^3.3.0"
+				"stringify-object": "3.3.0",
+				"supports-color": "8.1.1"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
 				"commander": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-					"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+					"version": "8.2.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-8.2.0.tgz",
+					"integrity": "sha512-LLKxDvHeL91/8MIyTAD5BFMNtoIwztGPMiM/7Bl8rIPmHCZXRxmSWr91h57dpOpnQ6jIUqEWdXE/uBYMfiVZDA==",
 					"dev": true
 				},
 				"execa": {
@@ -17698,9 +17648,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"version": "8.1.1",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+					"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -17709,9 +17659,9 @@
 			}
 		},
 		"listr2": {
-			"version": "3.12.1",
-			"resolved": "https://registry.npmjs.org/listr2/-/listr2-3.12.1.tgz",
-			"integrity": "sha512-oB1DlXlCzGPbvWhqYBZUQEPJKqsmebQWofXG6Mpbe3uIvoNl8mctBEojyF13ZyqwQ91clCWXpwsWp+t98K4FOQ==",
+			"version": "3.12.2",
+			"resolved": "https://registry.npmjs.org/listr2/-/listr2-3.12.2.tgz",
+			"integrity": "sha512-64xC2CJ/As/xgVI3wbhlPWVPx0wfTqbUAkpb7bjDi0thSWMqrf07UFhrfsGoo8YSXmF049Rp9C0cjLC8rZxK9A==",
 			"dev": true,
 			"requires": {
 				"cli-truncate": "^2.1.0",
@@ -17974,9 +17924,9 @@
 			}
 		},
 		"map-obj": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
-			"integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
 			"dev": true
 		},
 		"marky": {
@@ -18003,9 +17953,9 @@
 			"dev": true
 		},
 		"memfs": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/memfs/-/memfs-3.2.4.tgz",
-			"integrity": "sha512-2mDCPhuduRPOxlfgsXF9V+uqC6Jgz8zt/bNe4d4W7d5f6pCzHrWkxLNr17jKGXd4+j2kQNsAG2HARPnt74sqVQ==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/memfs/-/memfs-3.3.0.tgz",
+			"integrity": "sha512-BEE62uMfKOavX3iG7GYX43QJ+hAeeWnwIAuJ/R6q96jaMtiLzhsxHJC8B1L7fK7Pt/vXDRwb3SG/yBpNGDPqzg==",
 			"dev": true,
 			"requires": {
 				"fs-monkey": "1.0.3"
@@ -18086,18 +18036,18 @@
 			"dev": true
 		},
 		"mime-db": {
-			"version": "1.49.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
-			"integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==",
+			"version": "1.50.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
+			"integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.32",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
-			"integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
+			"version": "2.1.33",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
+			"integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.49.0"
+				"mime-db": "1.50.0"
 			}
 		},
 		"mimic-fn": {
@@ -18223,9 +18173,9 @@
 			"dev": true
 		},
 		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+			"version": "3.1.29",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.29.tgz",
+			"integrity": "sha512-dW2pUSGZ8ZnCFIlBIA31SV8huOGCHb6OwzVCc7A69rb/a+SgPBwfmLvK5TKQ3INPbRkcI8a/Owo0XbiTNH19wg==",
 			"dev": true
 		},
 		"natural-compare": {
@@ -18282,9 +18232,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.75",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
-			"integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
+			"version": "1.1.77",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.77.tgz",
+			"integrity": "sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ==",
 			"devOptional": true
 		},
 		"node-sass": {
@@ -18469,37 +18419,46 @@
 			}
 		},
 		"object.entries": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.4.tgz",
-			"integrity": "sha512-h4LWKWE+wKQGhtMjZEBud7uLGhqyLwj8fpHOarZhD2uY3C9cRtk57VQ89ke3moByLXMedqs3XCHzyb4AmA2DjA==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
+			"integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.2"
+				"es-abstract": "^1.19.1"
 			}
 		},
 		"object.fromentries": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.4.tgz",
-			"integrity": "sha512-EsFBshs5RUUpQEY1D4q/m59kMfz4YJvxuNCJcv/jWwOJr34EaVnG11ZrZa0UHB3wnzV1wx8m58T4hQL8IuNXlQ==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
+			"integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.0-next.2",
-				"has": "^1.0.3"
+				"es-abstract": "^1.19.1"
+			}
+		},
+		"object.hasown": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.0.tgz",
+			"integrity": "sha512-MhjYRfj3GBlhSkDHo6QmvgjRLXQ2zndabdf3nX0yTyZK9rPfxb6uRpAac8HXNLy1GpqWtZ81Qh4v3uOls2sRAg==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.19.1"
 			}
 		},
 		"object.values": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
-			"integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
+			"integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.2"
+				"es-abstract": "^1.19.1"
 			}
 		},
 		"obuf": {
@@ -18750,6 +18709,12 @@
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
 			"dev": true
 		},
+		"picocolors": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+			"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
+			"devOptional": true
+		},
 		"picomatch": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -18821,13 +18786,13 @@
 			}
 		},
 		"postcss": {
-			"version": "8.3.6",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
-			"integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
+			"version": "8.3.9",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.9.tgz",
+			"integrity": "sha512-f/ZFyAKh9Dnqytx5X62jgjhhzttjZS7hMsohcI7HEI5tjELX/HxCy3EFhsRxyzGvrzFF+82XPvCS8T9TFleVJw==",
 			"dev": true,
 			"requires": {
-				"colorette": "^1.2.2",
-				"nanoid": "^3.1.23",
+				"nanoid": "^3.1.28",
+				"picocolors": "^0.2.1",
 				"source-map-js": "^0.6.2"
 			}
 		},
@@ -18884,9 +18849,9 @@
 			"dev": true
 		},
 		"preact": {
-			"version": "10.5.14",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.5.14.tgz",
-			"integrity": "sha512-KojoltCrshZ099ksUZ2OQKfbH66uquFoxHSbnwKbTJHeQNvx42EmC7wQVWNuDt6vC5s3nudRHFtKbpY4ijKlaQ=="
+			"version": "10.5.15",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.5.15.tgz",
+			"integrity": "sha512-5chK29n6QcJc3m1lVrKQSQ+V7K1Gb8HeQY6FViQ5AxCAEGu3DaHffWNDkC9+miZgsLvbvU9rxbV1qinGHMHzqA=="
 		},
 		"prelude-ls": {
 			"version": "1.2.1",
@@ -18951,6 +18916,12 @@
 					"dev": true
 				}
 			}
+		},
+		"proxy-from-env": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+			"integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+			"dev": true
 		},
 		"ps-list": {
 			"version": "7.2.0",
@@ -19650,9 +19621,9 @@
 			}
 		},
 		"sass-loader": {
-			"version": "12.1.0",
-			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.1.0.tgz",
-			"integrity": "sha512-FVJZ9kxVRYNZTIe2xhw93n3xJNYZADr+q69/s98l9nTCrWASo+DR2Ot0s5xTKQDDEosUkatsGeHxcH4QBp5bSg==",
+			"version": "12.2.0",
+			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.2.0.tgz",
+			"integrity": "sha512-qducnp5vSV+8A8MZxuH6zV0MUg4MOVISScl2wDTCAn/2WJX+9Auxh92O/rnkdR2bvi5QxZBafnzkzRrWGZvm7w==",
 			"dev": true,
 			"requires": {
 				"klona": "^2.0.4",
@@ -19909,9 +19880,9 @@
 			}
 		},
 		"signal-exit": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.4.tgz",
-			"integrity": "sha512-rqYhcAnZ6d/vTPGghdrw7iumdcbXpsk1b8IG/rz+VWV51DM0p7XCtMoJ3qhPLIbp3tvyt3pKRbaaEMZYpHto8Q==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
+			"integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
 			"dev": true
 		},
 		"sirv": {
@@ -20165,25 +20136,25 @@
 			"dev": true
 		},
 		"string-width": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-			"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
 			"dev": true,
 			"requires": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.0"
+				"strip-ansi": "^6.0.1"
 			}
 		},
 		"string.prototype.matchall": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.5.tgz",
-			"integrity": "sha512-Z5ZaXO0svs0M2xd/6By3qpeKpLKd9mO4v4q3oMEQrk8Ck4xOD5d5XeBOOjGrmVZZ/AHB1S0CgG4N5r1G9N3E2Q==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz",
+			"integrity": "sha512-6WgDX8HmQqvEd7J+G6VtAahhsQIssiZ8zl7zKh1VDMFyL3hRTJP4FTNA3RbIp2TOQ9AYNDcc7e3fH0Qbup+DBg==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.2",
+				"es-abstract": "^1.19.1",
 				"get-intrinsic": "^1.1.1",
 				"has-symbols": "^1.0.2",
 				"internal-slot": "^1.0.3",
@@ -20231,12 +20202,12 @@
 			}
 		},
 		"strip-ansi": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-			"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^5.0.0"
+				"ansi-regex": "^5.0.1"
 			}
 		},
 		"strip-final-newline": {
@@ -20261,9 +20232,9 @@
 			"dev": true
 		},
 		"style-loader": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.2.1.tgz",
-			"integrity": "sha512-1k9ZosJCRFaRbY6hH49JFlRB0fVSbmnyq1iTPjNxUmGVjBNEmwrrHPenhlp+Lgo51BojHSf6pl2FcqYaN3PfVg==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.0.tgz",
+			"integrity": "sha512-szANub7ksJtQioJYtpbWwh1hUl99uK15n5HDlikeCRil/zYMZgSxucHddyF/4A3qJMUiAjPhFowrrQuNMA7jwQ==",
 			"dev": true,
 			"requires": {}
 		},
@@ -20291,17 +20262,17 @@
 			}
 		},
 		"table": {
-			"version": "6.7.1",
-			"resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
-			"integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
+			"version": "6.7.2",
+			"resolved": "https://registry.npmjs.org/table/-/table-6.7.2.tgz",
+			"integrity": "sha512-UFZK67uvyNivLeQbVtkiUs8Uuuxv24aSL4/Vil2PJVtMgU8Lx0CYkP12uCGa3kjyQzOSgV1+z9Wkb82fCGsO0g==",
 			"dev": true,
 			"requires": {
 				"ajv": "^8.0.1",
 				"lodash.clonedeep": "^4.5.0",
 				"lodash.truncate": "^4.4.2",
 				"slice-ansi": "^4.0.0",
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.0"
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1"
 			},
 			"dependencies": {
 				"ajv": {
@@ -20386,9 +20357,9 @@
 			"dev": true
 		},
 		"terser": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.8.0.tgz",
-			"integrity": "sha512-f0JH+6yMpneYcRJN314lZrSwu9eKkUFEHLN/kNy8ceh8gaRiLgFPJqrB9HsXjhEGdv4e/ekjTOFxIlL6xlma8A==",
+			"version": "5.9.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.9.0.tgz",
+			"integrity": "sha512-h5hxa23sCdpzcye/7b8YqbE5OwKca/ni0RQz1uRX3tGh8haaGHqcuSqbGRybuAKNdntZ0mDgFNXPJ48xQ2RXKQ==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.20.0",
@@ -20903,9 +20874,9 @@
 			}
 		},
 		"webpack": {
-			"version": "5.53.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.53.0.tgz",
-			"integrity": "sha512-RZ1Z3z3ni44snoWjfWeHFyzvd9HMVYDYC5VXmlYUT6NWgEOWdCNpad5Fve2CzzHoRED7WtsKe+FCyP5Vk4pWiQ==",
+			"version": "5.58.1",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.58.1.tgz",
+			"integrity": "sha512-4Z/dmbTU+VmkCb2XNgW7wkE5TfEcSooclprn/UEuVeAkwHhn07OcgUsyaKHGtCY/VobjnsYBlyhKeMLiSoOqPg==",
 			"dev": true,
 			"requires": {
 				"@types/eslint-scope": "^3.7.0",
@@ -20917,8 +20888,8 @@
 				"acorn-import-assertions": "^1.7.6",
 				"browserslist": "^4.14.5",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.8.0",
-				"es-module-lexer": "^0.7.1",
+				"enhanced-resolve": "^5.8.3",
+				"es-module-lexer": "^0.9.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
@@ -20941,9 +20912,9 @@
 					"dev": true
 				},
 				"acorn-import-assertions": {
-					"version": "1.7.6",
-					"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.7.6.tgz",
-					"integrity": "sha512-FlVvVFA1TX6l3lp8VjDnYYq7R1nyW6x3svAt4nDgrWQ9SBaSh9CnbwgSUTasgfNfOG5HlM1ehugCvM+hjo56LA==",
+					"version": "1.8.0",
+					"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+					"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
 					"dev": true,
 					"requires": {}
 				},
@@ -20961,15 +20932,15 @@
 			}
 		},
 		"webpack-bundle-analyzer": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.4.2.tgz",
-			"integrity": "sha512-PIagMYhlEzFfhMYOzs5gFT55DkUdkyrJi/SxJp8EF3YMWhS+T9vvs2EoTetpk5qb6VsCq02eXTlRDOydRhDFAQ==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.5.0.tgz",
+			"integrity": "sha512-GUMZlM3SKwS8Z+CKeIFx7CVoHn3dXFcUAjT/dcZQQmfSZGvitPfMob2ipjai7ovFFqPvTqkEZ/leL4O0YOdAYQ==",
 			"dev": true,
 			"requires": {
 				"acorn": "^8.0.4",
 				"acorn-walk": "^8.0.0",
 				"chalk": "^4.1.0",
-				"commander": "^6.2.0",
+				"commander": "^7.2.0",
 				"gzip-size": "^6.0.0",
 				"lodash": "^4.17.20",
 				"opener": "^1.5.2",
@@ -21018,9 +20989,9 @@
 					"dev": true
 				},
 				"commander": {
-					"version": "6.2.1",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-					"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+					"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
 					"dev": true
 				},
 				"has-flag": {
@@ -21041,16 +21012,16 @@
 			}
 		},
 		"webpack-cli": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.8.0.tgz",
-			"integrity": "sha512-+iBSWsX16uVna5aAYN6/wjhJy1q/GKk4KjKvfg90/6hykCTSgozbfz5iRgDTSJt/LgSbYxdBX3KBHeobIs+ZEw==",
+			"version": "4.9.0",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.0.tgz",
+			"integrity": "sha512-n/jZZBMzVEl4PYIBs+auy2WI0WTQ74EnJDiyD98O2JZY6IVIHJNitkYp/uTXOviIOMfgzrNvC9foKv/8o8KSZw==",
 			"dev": true,
 			"requires": {
 				"@discoveryjs/json-ext": "^0.5.0",
-				"@webpack-cli/configtest": "^1.0.4",
-				"@webpack-cli/info": "^1.3.0",
-				"@webpack-cli/serve": "^1.5.2",
-				"colorette": "^1.2.1",
+				"@webpack-cli/configtest": "^1.1.0",
+				"@webpack-cli/info": "^1.4.0",
+				"@webpack-cli/serve": "^1.6.0",
+				"colorette": "^2.0.14",
 				"commander": "^7.0.0",
 				"execa": "^5.0.0",
 				"fastest-levenshtein": "^1.0.12",
@@ -21061,6 +21032,12 @@
 				"webpack-merge": "^5.7.3"
 			},
 			"dependencies": {
+				"colorette": {
+					"version": "2.0.16",
+					"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+					"integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+					"dev": true
+				},
 				"commander": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -21099,18 +21076,24 @@
 			}
 		},
 		"webpack-dev-middleware": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.1.0.tgz",
-			"integrity": "sha512-oT660AR1gOnU/NTdUQi3EiGR0iXG7CFxmKsj3ylWCBA2khJ8LFHK+sKv3BZEsC11gl1eChsltRhzUq7nWj7XIQ==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.2.1.tgz",
+			"integrity": "sha512-Kx1X+36Rn9JaZcQMrJ7qN3PMAuKmEDD9ZISjUj3Cgq4A6PtwYsC4mpaKotSRYH3iOF6HsUa8viHKS59FlyVifQ==",
 			"dev": true,
 			"requires": {
-				"colorette": "^1.2.2",
+				"colorette": "^2.0.10",
 				"memfs": "^3.2.2",
 				"mime-types": "^2.1.31",
 				"range-parser": "^1.2.1",
 				"schema-utils": "^3.1.0"
 			},
 			"dependencies": {
+				"colorette": {
+					"version": "2.0.16",
+					"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+					"integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+					"dev": true
+				},
 				"schema-utils": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
@@ -21125,15 +21108,15 @@
 			}
 		},
 		"webpack-dev-server": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.2.1.tgz",
-			"integrity": "sha512-SQrIyQDZsTaF84p/WMAXNRKxjTeIaewhDIiHYZ423ENhNAsQWyubvqPTn0IoLMGkbhWyWv8/GYnCjItt0ZNC5w==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.3.1.tgz",
+			"integrity": "sha512-qNXQCVYo1kYhH9pgLtm8LRNkXX3XzTfHSj/zqzaqYzGPca+Qjr+81wj1jgPMCHhIhso9WEQ+kX9z23iG9PzQ7w==",
 			"dev": true,
 			"requires": {
 				"ansi-html-community": "^0.0.8",
 				"bonjour": "^3.5.0",
 				"chokidar": "^3.5.1",
-				"colorette": "^1.2.2",
+				"colorette": "^2.0.10",
 				"compression": "^1.7.4",
 				"connect-history-api-fallback": "^1.6.0",
 				"del": "^6.0.0",
@@ -21153,7 +21136,7 @@
 				"spdy": "^4.0.2",
 				"strip-ansi": "^7.0.0",
 				"url": "^0.11.0",
-				"webpack-dev-middleware": "^5.1.0",
+				"webpack-dev-middleware": "^5.2.1",
 				"ws": "^8.1.0"
 			},
 			"dependencies": {
@@ -21163,10 +21146,16 @@
 					"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
 					"dev": true
 				},
+				"colorette": {
+					"version": "2.0.16",
+					"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+					"integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+					"dev": true
+				},
 				"open": {
-					"version": "8.2.1",
-					"resolved": "https://registry.npmjs.org/open/-/open-8.2.1.tgz",
-					"integrity": "sha512-rXILpcQlkF/QuFez2BJDf3GsqpjGKbkUUToAIGo9A0Q6ZkoSGogZJulrUdwRkrAsoQvoZsrjCYt8+zblOk7JQQ==",
+					"version": "8.3.0",
+					"resolved": "https://registry.npmjs.org/open/-/open-8.3.0.tgz",
+					"integrity": "sha512-7INcPWb1UcOwSQxAXTnBJ+FxVV4MPs/X++FWWBtgY69/J5lc+tCteMt/oFK1MnkyHC4VILLa9ntmwKTwDR4Q9w==",
 					"dev": true,
 					"requires": {
 						"define-lazy-prop": "^2.0.0",
@@ -21195,9 +21184,9 @@
 					}
 				},
 				"ws": {
-					"version": "8.2.2",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-8.2.2.tgz",
-					"integrity": "sha512-Q6B6H2oc8QY3llc3cB8kVmQ6pnJWVQbP7Q5algTcIxx7YEpc0oU4NBVHlztA7Ekzfhw2r0rPducMUiCGWKQRzw==",
+					"version": "8.2.3",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+					"integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
 					"dev": true,
 					"requires": {}
 				}

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
 	"license": "MIT",
 	"prettier": "@searchspring/prettier",
 	"dependencies": {
-		"@searchspring/snap-preact": "^0.9.3",
-		"@searchspring/snap-preact-components": "^0.9.3",
+		"@searchspring/snap-preact": "^0.9.7",
+		"@searchspring/snap-preact-components": "^0.9.7",
 		"mobx": "^6.3.3",
 		"mobx-react": "^7.2.0",
 		"preact": "^10.5.14"

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -9,10 +9,14 @@ module.exports = {
 		modulesSort: 'size',
 		modulesSpace: 70,
 	},
-	plugins:[
+	plugins: [
 		new webpack.DefinePlugin({
 			BRANCHNAME: `"${branchName}"`,
-		})
+		}),
+		// code splitting chunks
+		new webpack.optimize.LimitChunkCountPlugin({
+			maxChunks: 1,
+		}),
 	],
 	module: {
 		rules: [


### PR DESCRIPTION
Only way to make the bundle file exist as one large file now is to disable code splitting (or limit it to one file). This should add another nice test comparison to our existing set of builds.